### PR TITLE
Field import: per-camera frame_id parameter for sea_surface_segmentation (2026-04-27)

### DIFF
--- a/depthai_marine/docs/API.md
+++ b/depthai_marine/docs/API.md
@@ -12,7 +12,7 @@ Base class for creating DepthAI camera nodes in the UNH Marine Autonomy framewor
 | Method | Description |
 |---|---|
 | `CameraBase(std::shared_ptr<rclcpp::Node> node)` | Constructor. Requires a ROS 2 node handle. |
-| `void initialize(std::string id, std::string label)` | Initializes the connection to the OAK device with the given MXID (`id`) and assigns a logger label. |
+| `void initialize(std::string id, std::string label, std::string frame_id = "")` | Initializes the connection to the OAK device with the given MXID (`id`) and assigns a logger label. `frame_id` stamps `header.frame_id` on every `Image` / `CameraInfo` / `FFMPEGPacket` from the publishers this method constructs; when empty, defaults to `<label>_optical_frame` (`image_geometry` / REP-103 convention). Pass explicitly for namespaced frames (e.g. `"bizzy/oak_forward_optical"`). |
 | `void applyParams(const CameraParams & params)` | Bulk-applies all per-camera settings before `initialize`. See `CameraParams`. |
 | `void setPreviewSize(int width, int height)` | Sets the resolution of the camera preview output (default 1280×720). |
 | `void setVideoSize(int width, int height)` | Sets the ISP output resolution that feeds both `video` (H.265 encoder input) and `preview` (default 1280×720). |
@@ -58,6 +58,12 @@ QoS is `rclcpp::SensorDataQoS()` to match the `ffmpeg_image_transport` subscribe
 convention. Instantiated automatically by `CameraBase::initialize()` when
 `h265_enable=true` — see [h265_transport.md](h265_transport.md).
 
+The constructor takes an optional `frame_id` parameter (after `encoding`) that
+stamps `header.frame_id` on every published `FFMPEGPacket`. When empty, falls
+back to `topic_name` for backwards compatibility; `CameraBase::initialize()`
+provides the URDF-aligned `<label>_optical_frame` default for callers that
+go through it.
+
 ### `depthai_marine::ImagePublisher`
 A helper class wrapping `depthai_bridge` to publish images from a DepthAI queue to a ROS 2 topic.
 
@@ -67,7 +73,7 @@ A helper class wrapping `depthai_bridge` to publish images from a DepthAI queue 
 #### Public Methods
 | Method | Description |
 |---|---|
-| `ImagePublisher(std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Device> device, std::string queue_name, std::string topic_name)` | Connects a `DataOutputQueue` from the device to a ROS publisher on `topic_name`. |
+| `ImagePublisher(std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Device> device, std::string queue_name, std::string topic_name, std::string frame_id = "")` | Connects a `DataOutputQueue` from the device to a ROS publisher on `topic_name`. `frame_id` stamps `header.frame_id` on every `Image` / `CameraInfo`; when empty, falls back to `topic_name` for backwards compatibility. Most callers should go through `CameraBase::initialize()`, which provides the URDF-aligned `<label>_optical_frame` default. |
 
 #### Usage Example
 ```cpp

--- a/depthai_marine/docs/h265_transport.md
+++ b/depthai_marine/docs/h265_transport.md
@@ -26,8 +26,11 @@ timestamps for each physical frame.
 Field mapping on each `FFMPEGPacket` (filled in by `toRosFFMPEGPacket`):
 
 - `header.stamp` — ROS time, base-offset from `EncodedFrame::getTimestamp()`.
-- `header.frame_id` — the camera label passed to `FFMPEGPublisher` (same as the
-  sibling `sensor_msgs/Image`'s `frame_id`).
+- `header.frame_id` — the `frame_id` passed to `FFMPEGPublisher` (same as the
+  sibling `sensor_msgs/Image`'s `frame_id`). When `CameraBase::initialize()`
+  constructs the publisher, this defaults to `<label>_optical_frame` to match
+  the URDF / `image_geometry` convention; callers can override by passing an
+  explicit `frame_id` to `initialize()`.
 - `width` / `height` — from `EncodedFrame::getWidth()` / `getHeight()`.
 - `encoding` — `"hevc"` for H.265 profiles, `"h264"` for H.264 profiles;
   configured via `ImageConverter::setFFMPEGEncoding` at `FFMPEGPublisher`

--- a/depthai_marine/include/depthai_marine/camera_base.hpp
+++ b/depthai_marine/include/depthai_marine/camera_base.hpp
@@ -33,7 +33,15 @@ class CameraBase
 public:
   CameraBase(std::shared_ptr<rclcpp::Node> node);
 
-  virtual void initialize(std::string id, std::string label);
+  // `frame_id` stamps `header.frame_id` on every Image / CameraInfo /
+  // FFMPEGPacket emitted by the publishers this method constructs. When
+  // empty, defaults to `<label>_optical_frame` (the URDF convention for
+  // `image_geometry`-style optical frames). Callers that want a different
+  // frame name (e.g. namespaced `bizzy/oak_forward_optical`) pass it
+  // explicitly. The previous behavior — `frame_id == label` — is not
+  // preserved on this path; callers that need the raw `label` must pass
+  // it through explicitly.
+  virtual void initialize(std::string id, std::string label, std::string frame_id = "");
   void applyParams(const CameraParams & params);
   void setPreviewSize(int width, int height);
   void setVideoSize(int width, int height);

--- a/depthai_marine/include/depthai_marine/ffmpeg_publisher.hpp
+++ b/depthai_marine/include/depthai_marine/ffmpeg_publisher.hpp
@@ -28,12 +28,18 @@ namespace depthai_marine {
 class FFMPEGPublisher
 {
 public:
+  // `frame_id` stamps `header.frame_id` on every published FFMPEGPacket.
+  // When empty, falls back to `topic_name` to preserve the historical
+  // default. Callers that want the URDF-aligned `<label>_optical_frame`
+  // default should go through `CameraBase::initialize()`, which derives it
+  // for them.
   FFMPEGPublisher(
     std::shared_ptr<rclcpp::Node> node,
     std::shared_ptr<dai::Device> device,
     const std::string & queue_name,
     const std::string & topic_name,
-    const std::string & encoding);
+    const std::string & encoding,
+    const std::string & frame_id = "");
 
   ~FFMPEGPublisher();
 

--- a/depthai_marine/include/depthai_marine/image_publisher.hpp
+++ b/depthai_marine/include/depthai_marine/image_publisher.hpp
@@ -10,7 +10,16 @@ namespace depthai_marine {
 class ImagePublisher
 {
 public:
-  ImagePublisher(std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Device> device, std::string queue_name, std::string topic_name);
+  // `frame_id` stamps `header.frame_id` on every published Image / CameraInfo.
+  // When empty, falls back to `topic_name` to preserve the historical default.
+  // Callers that want the URDF-aligned `<label>_optical_frame` default should
+  // go through `CameraBase::initialize()`, which derives it for them.
+  ImagePublisher(
+    std::shared_ptr<rclcpp::Node> node,
+    std::shared_ptr<dai::Device> device,
+    std::string queue_name,
+    std::string topic_name,
+    std::string frame_id = "");
 
 private:
   std::shared_ptr<dai::DataOutputQueue> camera_queue_;

--- a/depthai_marine/src/camera_base.cpp
+++ b/depthai_marine/src/camera_base.cpp
@@ -36,7 +36,7 @@ std::string CameraBase::profileEncoding(dai::VideoEncoderProperties::Profile pro
   }
 }
 
-void CameraBase::initialize(std::string id, std::string label)
+void CameraBase::initialize(std::string id, std::string label, std::string frame_id)
 {
   auto pipeline = getPipeline();
 
@@ -62,8 +62,15 @@ void CameraBase::initialize(std::string id, std::string label)
 
   RCLCPP_INFO_STREAM(node_->get_logger(), label << ": Connected to device: " <<  device_->getDeviceInfo().toString());
 
+  // URDF-aligned default: `<label>_optical_frame` matches the
+  // `image_geometry` / REP-103 convention for camera optical frames. This
+  // is a behavioral change from the historical default (which was the bare
+  // `label`) — callers that need the raw `label` must now pass it
+  // explicitly. See sea_surface_segmentation for the pass-through pattern.
+  const std::string resolved_frame_id = frame_id.empty() ? (label + "_optical_frame") : frame_id;
+
   if (enable_video_) {
-    camera_publisher_ = std::make_shared<ImagePublisher>(node_, device_, "camera", label);
+    camera_publisher_ = std::make_shared<ImagePublisher>(node_, device_, "camera", label, resolved_frame_id);
   }
 
   if (h265_enable_) {
@@ -73,7 +80,8 @@ void CameraBase::initialize(std::string id, std::string label)
       device_,
       "ffmpeg",
       label,
-      profileEncoding(profile));
+      profileEncoding(profile),
+      resolved_frame_id);
   }
 }
 

--- a/depthai_marine/src/ffmpeg_publisher.cpp
+++ b/depthai_marine/src/ffmpeg_publisher.cpp
@@ -7,7 +7,8 @@ FFMPEGPublisher::FFMPEGPublisher(
   std::shared_ptr<dai::Device> device,
   const std::string & queue_name,
   const std::string & topic_name,
-  const std::string & encoding)
+  const std::string & encoding,
+  const std::string & frame_id)
 : node_(node),
   callback_id_(-1)
 {
@@ -16,7 +17,12 @@ FFMPEGPublisher::FFMPEGPublisher(
   // steady-clock base offset at construction; as long as both clocks advance
   // at the same rate (they do on Linux), two converters constructed moments
   // apart produce matching stamps for any given device frame.
-  converter_ = std::make_shared<dai::ros::ImageConverter>(topic_name, true);
+  //
+  // Empty frame_id → historical behavior: stamp with `topic_name`. Callers
+  // that want the URDF-aligned `<label>_optical_frame` default go through
+  // CameraBase::initialize(), which derives it before getting here.
+  const std::string & resolved_frame_id = frame_id.empty() ? topic_name : frame_id;
+  converter_ = std::make_shared<dai::ros::ImageConverter>(resolved_frame_id, true);
   converter_->setFFMPEGEncoding(encoding);
 
   publisher_ = node_->create_publisher<ffmpeg_image_transport_msgs::msg::FFMPEGPacket>(

--- a/depthai_marine/src/image_publisher.cpp
+++ b/depthai_marine/src/image_publisher.cpp
@@ -2,12 +2,16 @@
 
 namespace depthai_marine {
 
-ImagePublisher::ImagePublisher(std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Device> device, std::string queue_name, std::string topic_name)
+ImagePublisher::ImagePublisher(std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Device> device, std::string queue_name, std::string topic_name, std::string frame_id)
 {
   camera_queue_ = device->getOutputQueue(queue_name, 5, false);
 
   auto calibration_handler = device->readCalibration();
-  image_converter_ = std::make_shared<dai::rosBridge::ImageConverter>(topic_name, true);
+  // Empty frame_id → historical behavior: stamp with `topic_name`. Callers
+  // that want the URDF-aligned `<label>_optical_frame` default go through
+  // CameraBase::initialize(), which derives it before getting here.
+  const std::string & resolved_frame_id = frame_id.empty() ? topic_name : frame_id;
+  image_converter_ = std::make_shared<dai::rosBridge::ImageConverter>(resolved_frame_id, true);
 
   auto camera_info = image_converter_->calibrationToCameraInfo(calibration_handler, dai::CameraBoardSocket::CAM_A, 1280, 720);
 

--- a/depthai_marine/test/test_h265_params.cpp
+++ b/depthai_marine/test/test_h265_params.cpp
@@ -115,6 +115,67 @@ TEST(CameraBaseValidation, SetH265KeyframeFrequencyFramesRejectsNonPositive)
   EXPECT_NO_THROW(base.setH265KeyframeFrequencyFrames(30));
 }
 
+TEST(ApplyParams, RoundTripH265Pipeline)
+{
+  // Round-trip: a non-default CameraParams should drive applyParams() and
+  // emerge through getPipeline() without throwing. Catches the case where
+  // a future setter starts validating in a way the others don't.
+  auto node = std::make_shared<rclcpp::Node>("applyparams_roundtrip_h265_test");
+  CameraBase base(node);
+  depthai_marine::CameraParams params;
+  params.preview_width = 640;
+  params.preview_height = 360;
+  params.video_width = 1920;
+  params.video_height = 1080;
+  params.fps = 10.0f;
+  params.enable_video = true;
+  params.h265_enable = true;
+  params.h265_bitrate_kbps = 800;
+  params.h265_keyframe_frequency_frames = 60;
+  params.h265_profile = "H264_HIGH";
+  EXPECT_NO_THROW(base.applyParams(params));
+  EXPECT_NO_THROW(base.getPipeline());
+}
+
+TEST(ApplyParams, InvalidVideoSizeFromParamsThrows)
+{
+  // applyParams should propagate the per-setter validation. Any param
+  // that fails its own validator must fail applyParams().
+  auto node = std::make_shared<rclcpp::Node>("applyparams_invalid_video_test");
+  CameraBase base(node);
+  depthai_marine::CameraParams params;
+  params.video_width = 0;  // setVideoSize rejects this
+  EXPECT_THROW(base.applyParams(params), std::invalid_argument);
+}
+
+TEST(SetH265Profile, InvalidProfileFailsLazilyAtPipelineAssembly)
+{
+  // setH265Profile is intentionally lazy — the string is only validated
+  // when getPipeline() / initialize() needs to map it to a DepthAI
+  // Profile enum. This test pins that contract: an invalid profile is
+  // accepted by the setter but rejected at pipeline assembly when h265
+  // is enabled. Keeps a future "validate eagerly" change from silently
+  // changing the failure point on platforms.
+  auto node = std::make_shared<rclcpp::Node>("setprofile_lazy_test");
+  CameraBase base(node);
+  EXPECT_NO_THROW(base.setH265Profile("NOT_A_REAL_PROFILE"));
+  base.enableH265(true);
+  EXPECT_THROW(base.getPipeline(), std::invalid_argument);
+}
+
+TEST(SetH265Profile, InvalidProfileIsBenignWhenH265Disabled)
+{
+  // The lazy validation only fires when h265 is enabled. With h265 off,
+  // a stale/garbage profile string must not break pipeline assembly —
+  // BizzyBoat ships some cameras with h265_enable=False, and those
+  // shouldn't trip on a profile string they never use.
+  auto node = std::make_shared<rclcpp::Node>("setprofile_disabled_test");
+  CameraBase base(node);
+  base.setH265Profile("NOT_A_REAL_PROFILE");
+  base.enableH265(false);
+  EXPECT_NO_THROW(base.getPipeline());
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/depthai_marine/test/test_h265_params.cpp
+++ b/depthai_marine/test/test_h265_params.cpp
@@ -115,12 +115,19 @@ TEST(CameraBaseValidation, SetH265KeyframeFrequencyFramesRejectsNonPositive)
   EXPECT_NO_THROW(base.setH265KeyframeFrequencyFrames(30));
 }
 
-TEST(ApplyParams, RoundTripH265Pipeline)
+TEST(ApplyParams, RoundTripEncoderPipelineH264Profile)
 {
   // Round-trip: a non-default CameraParams should drive applyParams() and
   // emerge through getPipeline() without throwing. Catches the case where
   // a future setter starts validating in a way the others don't.
-  auto node = std::make_shared<rclcpp::Node>("applyparams_roundtrip_h265_test");
+  //
+  // `h265_enable` is the encoder-pipeline gate, not strictly the H.265
+  // gate — getPipeline() spins up a VideoEncoder when it's true, with
+  // `h265_profile` deciding the actual codec (H264_* or H265_*). We
+  // pick H264_HIGH here precisely to exercise that distinction: the
+  // encoder branch must be reachable for every supported profile, not
+  // just H265_MAIN.
+  auto node = std::make_shared<rclcpp::Node>("applyparams_roundtrip_encoder_h264_test");
   CameraBase base(node);
   depthai_marine::CameraParams params;
   params.preview_width = 640;

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -29,10 +29,6 @@ add_executable(
   src/sea_surface_segmentation.cpp
 )
 
-target_include_directories(sea_surface_segmentation PRIVATE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-)
-
 target_link_libraries(sea_surface_segmentation
   depthai::core
   depthai_bridge::depthai_bridge
@@ -99,8 +95,10 @@ install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_frame_id_resolver test/test_frame_id_resolver.cpp)
+  # Resolver header is private to the executable (lives next to its
+  # .cpp in src/), so the test target needs its own path into src/.
   target_include_directories(test_frame_id_resolver PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
   )
 endif()
 

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -29,6 +29,10 @@ add_executable(
   src/sea_surface_segmentation.cpp
 )
 
+target_include_directories(sea_surface_segmentation PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+
 target_link_libraries(sea_surface_segmentation
   depthai::core
   depthai_bridge::depthai_bridge
@@ -91,5 +95,13 @@ install(
 
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_frame_id_resolver test/test_frame_id_resolver.cpp)
+  target_include_directories(test_frame_id_resolver PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  )
+endif()
 
 ament_package()

--- a/sea_surface_segmentation/include/sea_surface_segmentation/frame_id_resolver.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/frame_id_resolver.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace sea_surface_segmentation {
+
+// Resolve the per-camera `frame_id` used to stamp segmentation outputs.
+//
+// Behavior:
+//   - `frame_ids` empty → every camera gets the historical default
+//     `<camera_name>_optical_frame`.
+//   - `frame_ids.size() == camera_names.size()` → element-wise override,
+//     except an empty string entry falls back to the historical default
+//     for that camera.
+//   - Any other size → `std::invalid_argument`.
+//
+// The default branch must match the literal hard-coded in
+// `SegmentorCamera`'s constructor before the refactor.
+inline std::vector<std::string> resolve_frame_ids(
+  const std::vector<std::string> & camera_names,
+  const std::vector<std::string> & frame_ids)
+{
+  if (!frame_ids.empty() && frame_ids.size() != camera_names.size()) {
+    throw std::invalid_argument(
+      "frame_ids length (" + std::to_string(frame_ids.size()) +
+      ") must match camera_names length (" + std::to_string(camera_names.size()) +
+      ") when set");
+  }
+
+  std::vector<std::string> resolved;
+  resolved.reserve(camera_names.size());
+  for (size_t i = 0; i < camera_names.size(); ++i) {
+    const bool have_override = i < frame_ids.size() && !frame_ids[i].empty();
+    resolved.push_back(have_override ? frame_ids[i] : (camera_names[i] + "_optical_frame"));
+  }
+  return resolved;
+}
+
+}  // namespace sea_surface_segmentation

--- a/sea_surface_segmentation/package.xml
+++ b/sea_surface_segmentation/package.xml
@@ -22,6 +22,7 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/sea_surface_segmentation/src/frame_id_resolver.hpp
+++ b/sea_surface_segmentation/src/frame_id_resolver.hpp
@@ -1,5 +1,11 @@
 #pragma once
 
+// Private implementation header for the sea_surface_segmentation node.
+// Lives in src/ rather than include/ because the resolver has no
+// downstream consumers — it's exercised by `src/sea_surface_segmentation.cpp`
+// and by `test/test_frame_id_resolver.cpp`, nothing else.
+
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -31,7 +37,7 @@ inline std::vector<std::string> resolve_frame_ids(
 
   std::vector<std::string> resolved;
   resolved.reserve(camera_names.size());
-  for (size_t i = 0; i < camera_names.size(); ++i) {
+  for (std::size_t i = 0; i < camera_names.size(); ++i) {
     const bool have_override = i < frame_ids.size() && !frame_ids[i].empty();
     resolved.push_back(have_override ? frame_ids[i] : (camera_names[i] + "_optical_frame"));
   }

--- a/sea_surface_segmentation/src/sea_surface_segmentation.cpp
+++ b/sea_surface_segmentation/src/sea_surface_segmentation.cpp
@@ -36,7 +36,14 @@ public:
     enable_nn_(enable_nn)
   {
     applyParams(params);
-    initialize(id, name);
+    // Pass `frame_id_` (either a per-camera override from the `frame_ids`
+    // ROS param or the resolved `<name>_optical_frame` default) through to
+    // CameraBase so the sibling video / H.265 publishers stamp messages
+    // with the same frame_id as the NN/segmentation output. Without this,
+    // only the segmentation Image carried the URDF-aligned frame; video
+    // and H.265 packets fell back to the bare `name` (e.g. `oak_forward`),
+    // breaking TF lookups for any consumer of those topics.
+    initialize(id, name, frame_id_);
 
     if (enable_nn_) {
         segmentation_queue_ = device_->getOutputQueue("neural_network", 5, false);

--- a/sea_surface_segmentation/src/sea_surface_segmentation.cpp
+++ b/sea_surface_segmentation/src/sea_surface_segmentation.cpp
@@ -18,7 +18,7 @@
 #include "depthai_marine/camera_base.hpp"
 #include "depthai_marine/image_publisher.hpp"
 
-#include "sea_surface_segmentation/frame_id_resolver.hpp"
+#include "frame_id_resolver.hpp"
 
 class SegmentorCamera : public depthai_marine::CameraBase
 {

--- a/sea_surface_segmentation/src/sea_surface_segmentation.cpp
+++ b/sea_surface_segmentation/src/sea_surface_segmentation.cpp
@@ -18,11 +18,22 @@
 #include "depthai_marine/camera_base.hpp"
 #include "depthai_marine/image_publisher.hpp"
 
+#include "sea_surface_segmentation/frame_id_resolver.hpp"
+
 class SegmentorCamera : public depthai_marine::CameraBase
 {
 public:
-  SegmentorCamera(std::shared_ptr<rclcpp::Node> node, std::string id, std::string name, const depthai_marine::CameraParams & params, bool enable_nn, const std::string & frame_id_override = "")
-  : depthai_marine::CameraBase(node), name_(name), enable_nn_(enable_nn)
+  SegmentorCamera(
+    std::shared_ptr<rclcpp::Node> node,
+    std::string id,
+    std::string name,
+    const depthai_marine::CameraParams & params,
+    bool enable_nn,
+    std::string frame_id)
+  : depthai_marine::CameraBase(node),
+    name_(name),
+    frame_id_(std::move(frame_id)),
+    enable_nn_(enable_nn)
   {
     applyParams(params);
     initialize(id, name);
@@ -31,13 +42,6 @@ public:
         segmentation_queue_ = device_->getOutputQueue("neural_network", 5, false);
 
         auto calibration_handler = device_->readCalibration();
-
-        // Frame the segmentation Image + CameraInfo are stamped with.
-        // Default mirrors the historical behavior; an explicit override lets
-        // the platform launch align with its URDF-published frames (which on
-        // BizzyBoat live under the `bizzy/` namespace and use `_optical`,
-        // not `_optical_frame`).
-        frame_id_ = frame_id_override.empty() ? (name_ + "_optical_frame") : frame_id_override;
 
         segmentation_converter_ = std::make_shared<dai::rosBridge::ImageConverter>(frame_id_, true);
         segmentation_camera_info_ = segmentation_converter_->calibrationToCameraInfo(calibration_handler, dai::CameraBoardSocket::CAM_A, 128, 96);
@@ -171,11 +175,13 @@ public:
         RCLCPP_ERROR(this->get_logger(), "Number of camera IDs and names must match!");
         return;
     }
-    if (!frame_ids.empty() && frame_ids.size() != camera_names.size()) {
-        RCLCPP_ERROR(this->get_logger(),
-            "frame_ids length (%zu) must match camera_names length (%zu) when set",
-            frame_ids.size(), camera_names.size());
-        return;
+
+    std::vector<std::string> resolved_frame_ids;
+    try {
+      resolved_frame_ids = sea_surface_segmentation::resolve_frame_ids(camera_names, frame_ids);
+    } catch (const std::invalid_argument & e) {
+      RCLCPP_ERROR(this->get_logger(), "%s", e.what());
+      return;
     }
 
     depthai_marine::CameraParams params;
@@ -193,12 +199,17 @@ public:
     bool enable_nn = get_parameter("enable_nn").as_bool();
 
     for (size_t i = 0; i < camera_ids.size(); ++i) {
-        const std::string frame_id_override = (i < frame_ids.size()) ? frame_ids[i] : std::string();
         RCLCPP_INFO(get_logger(),
             "Initializing camera: %s (MxId: %s, frame_id: %s)",
             camera_names[i].c_str(), camera_ids[i].c_str(),
-            frame_id_override.empty() ? "<default>" : frame_id_override.c_str());
-        auto cam = std::make_shared<SegmentorCamera>(shared_from_this(), camera_ids[i], camera_names[i], params, enable_nn, frame_id_override);
+            resolved_frame_ids[i].c_str());
+        auto cam = std::make_shared<SegmentorCamera>(
+            shared_from_this(),
+            camera_ids[i],
+            camera_names[i],
+            params,
+            enable_nn,
+            resolved_frame_ids[i]);
         cameras_.push_back(cam);
     }
   }

--- a/sea_surface_segmentation/src/sea_surface_segmentation.cpp
+++ b/sea_surface_segmentation/src/sea_surface_segmentation.cpp
@@ -145,8 +145,11 @@ public:
 
     this->declare_parameter("camera_ids", std::vector<std::string>());
     this->declare_parameter("camera_names", std::vector<std::string>());
-    // Optional, per-camera. Empty entries (or a shorter array) fall back to
-    // the historical default: `<camera_name>_optical_frame`.
+    // Optional. Either empty (every camera gets the historical default
+    // `<camera_name>_optical_frame`) or the same length as camera_names
+    // (per-camera override; a per-entry empty string falls back to the
+    // historical default for that one camera). Any other length is a
+    // configuration error and the node refuses to initialize.
     this->declare_parameter("frame_ids", std::vector<std::string>());
 
     declare_parameter("neural_network", std::string(""));

--- a/sea_surface_segmentation/src/sea_surface_segmentation.cpp
+++ b/sea_surface_segmentation/src/sea_surface_segmentation.cpp
@@ -21,18 +21,23 @@
 class SegmentorCamera : public depthai_marine::CameraBase
 {
 public:
-  SegmentorCamera(std::shared_ptr<rclcpp::Node> node, std::string id, std::string name, const depthai_marine::CameraParams & params, bool enable_nn)
+  SegmentorCamera(std::shared_ptr<rclcpp::Node> node, std::string id, std::string name, const depthai_marine::CameraParams & params, bool enable_nn, const std::string & frame_id_override = "")
   : depthai_marine::CameraBase(node), name_(name), enable_nn_(enable_nn)
   {
     applyParams(params);
     initialize(id, name);
-    
+
     if (enable_nn_) {
         segmentation_queue_ = device_->getOutputQueue("neural_network", 5, false);
 
         auto calibration_handler = device_->readCalibration();
-        
-        frame_id_ = name_ + "_optical_frame";
+
+        // Frame the segmentation Image + CameraInfo are stamped with.
+        // Default mirrors the historical behavior; an explicit override lets
+        // the platform launch align with its URDF-published frames (which on
+        // BizzyBoat live under the `bizzy/` namespace and use `_optical`,
+        // not `_optical_frame`).
+        frame_id_ = frame_id_override.empty() ? (name_ + "_optical_frame") : frame_id_override;
 
         segmentation_converter_ = std::make_shared<dai::rosBridge::ImageConverter>(frame_id_, true);
         segmentation_camera_info_ = segmentation_converter_->calibrationToCameraInfo(calibration_handler, dai::CameraBoardSocket::CAM_A, 128, 96);
@@ -136,6 +141,9 @@ public:
 
     this->declare_parameter("camera_ids", std::vector<std::string>());
     this->declare_parameter("camera_names", std::vector<std::string>());
+    // Optional, per-camera. Empty entries (or a shorter array) fall back to
+    // the historical default: `<camera_name>_optical_frame`.
+    this->declare_parameter("frame_ids", std::vector<std::string>());
 
     declare_parameter("neural_network", std::string(""));
 
@@ -157,9 +165,16 @@ public:
   {
     std::vector<std::string> camera_ids = this->get_parameter("camera_ids").as_string_array();
     std::vector<std::string> camera_names = this->get_parameter("camera_names").as_string_array();
+    std::vector<std::string> frame_ids = this->get_parameter("frame_ids").as_string_array();
 
     if (camera_ids.size() != camera_names.size()) {
         RCLCPP_ERROR(this->get_logger(), "Number of camera IDs and names must match!");
+        return;
+    }
+    if (!frame_ids.empty() && frame_ids.size() != camera_names.size()) {
+        RCLCPP_ERROR(this->get_logger(),
+            "frame_ids length (%zu) must match camera_names length (%zu) when set",
+            frame_ids.size(), camera_names.size());
         return;
     }
 
@@ -178,8 +193,12 @@ public:
     bool enable_nn = get_parameter("enable_nn").as_bool();
 
     for (size_t i = 0; i < camera_ids.size(); ++i) {
-        RCLCPP_INFO(get_logger(), "Initializing camera: %s (MxId: %s)", camera_names[i].c_str(), camera_ids[i].c_str());
-        auto cam = std::make_shared<SegmentorCamera>(shared_from_this(), camera_ids[i], camera_names[i], params, enable_nn);
+        const std::string frame_id_override = (i < frame_ids.size()) ? frame_ids[i] : std::string();
+        RCLCPP_INFO(get_logger(),
+            "Initializing camera: %s (MxId: %s, frame_id: %s)",
+            camera_names[i].c_str(), camera_ids[i].c_str(),
+            frame_id_override.empty() ? "<default>" : frame_id_override.c_str());
+        auto cam = std::make_shared<SegmentorCamera>(shared_from_this(), camera_ids[i], camera_names[i], params, enable_nn, frame_id_override);
         cameras_.push_back(cam);
     }
   }

--- a/sea_surface_segmentation/test/test_frame_id_resolver.cpp
+++ b/sea_surface_segmentation/test/test_frame_id_resolver.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "sea_surface_segmentation/frame_id_resolver.hpp"
+
+using sea_surface_segmentation::resolve_frame_ids;
+
+TEST(ResolveFrameIds, EmptyFrameIdsUsesDefaults)
+{
+  const std::vector<std::string> names = {"oak_forward", "oak_port"};
+  const auto resolved = resolve_frame_ids(names, {});
+  ASSERT_EQ(resolved.size(), 2u);
+  EXPECT_EQ(resolved[0], "oak_forward_optical_frame");
+  EXPECT_EQ(resolved[1], "oak_port_optical_frame");
+}
+
+TEST(ResolveFrameIds, FullArrayOverridesEachCamera)
+{
+  const std::vector<std::string> names = {"oak_forward", "oak_port"};
+  const std::vector<std::string> overrides = {"bizzy/oak_forward_optical", "bizzy/oak_port_optical"};
+  const auto resolved = resolve_frame_ids(names, overrides);
+  ASSERT_EQ(resolved.size(), 2u);
+  EXPECT_EQ(resolved[0], "bizzy/oak_forward_optical");
+  EXPECT_EQ(resolved[1], "bizzy/oak_port_optical");
+}
+
+TEST(ResolveFrameIds, EmptyEntryFallsBackToDefault)
+{
+  // Mixed: per-entry empty string is the documented escape hatch for
+  // "default this one, override the rest" — needed when one camera in
+  // a multi-camera launch is unmapped.
+  const std::vector<std::string> names = {"oak_forward", "oak_port"};
+  const std::vector<std::string> overrides = {"bizzy/oak_forward_optical", ""};
+  const auto resolved = resolve_frame_ids(names, overrides);
+  ASSERT_EQ(resolved.size(), 2u);
+  EXPECT_EQ(resolved[0], "bizzy/oak_forward_optical");
+  EXPECT_EQ(resolved[1], "oak_port_optical_frame");
+}
+
+TEST(ResolveFrameIds, LengthMismatchThrows)
+{
+  const std::vector<std::string> names = {"oak_forward", "oak_port", "oak_aft"};
+  const std::vector<std::string> shorter = {"a", "b"};
+  const std::vector<std::string> longer = {"a", "b", "c", "d"};
+  EXPECT_THROW(resolve_frame_ids(names, shorter), std::invalid_argument);
+  EXPECT_THROW(resolve_frame_ids(names, longer), std::invalid_argument);
+}
+
+TEST(ResolveFrameIds, EmptyCameraNamesProducesEmptyResult)
+{
+  EXPECT_TRUE(resolve_frame_ids({}, {}).empty());
+}
+
+TEST(ResolveFrameIds, SingleCameraWithOverride)
+{
+  const auto resolved = resolve_frame_ids({"oak_forward"}, {"bizzy/oak_forward_optical"});
+  ASSERT_EQ(resolved.size(), 1u);
+  EXPECT_EQ(resolved[0], "bizzy/oak_forward_optical");
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/sea_surface_segmentation/test/test_frame_id_resolver.cpp
+++ b/sea_surface_segmentation/test/test_frame_id_resolver.cpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include "sea_surface_segmentation/frame_id_resolver.hpp"
+#include "frame_id_resolver.hpp"
 
 using sea_surface_segmentation::resolve_frame_ids;
 


### PR DESCRIPTION
## Summary

Field import from gitcloud — adds an optional `frame_ids` parameter to the `sea_surface_segmentation` node so platform launches can override the hardcoded `<name>_optical_frame` to match URDF-published TF frames. **Scope expanded during PR review** to cover the same `frame_id` mismatch on the sibling video / H.265 publisher paths constructed by `CameraBase::initialize()`.

- Original field-import commit (+25 / -6) in `sea_surface_segmentation/src/sea_surface_segmentation.cpp`, plus follow-up commits adding tests + addressing review feedback
- New (3 commits added 2026-04-28): `frame_id` plumbing through `ImagePublisher` / `FFMPEGPublisher` / `CameraBase::initialize()`; segmentor pass-through; docs update
- Backwards compatible at the library level (empty `frame_id` → historical default at the publisher layer); behavioral change at the `CameraBase::initialize()` boundary (default is now `<label>_optical_frame`, not bare `label`)
- Field-verified on `gabby` 2026-04-27 (segmentation path); video/H.265 paths covered by the same plumbing pattern, no field test needed (fix is preventative — no current in-tree TF consumer of those topics)

Closes #8.

## Cross-repo dependency

Depended on by [`rolker/unh_echoboats_project11` PR #95](https://github.com/rolker/unh_echoboats_project11/pull/95) — that PR's `1fe5884` wires `frame_ids` into BizzyBoat's `oak_cameras_launch.py`. **PR #95 should not merge until this one does**, or BizzyBoat's launch will pass an unknown parameter to this node.

## Behavioral change (silent default at `CameraBase::initialize()`)

`CameraBase::initialize(id, label)` now defaults `frame_id` to `<label>_optical_frame` when not passed explicitly. This is a silent change for direct callers of `CameraBase::initialize()` that previously relied on the bare `label`:

- `wide_stereo` `MainCamera`: `frame_id` `right` → `right_optical_frame`
- `wide_stereo` `SecondaryCamera`: `frame_id` `left` → `left_optical_frame`

Workspace grep confirms no in-tree TF consumer of `/image_raw` or `/image_raw/ffmpeg` from these nodes today, so this lands without breaking a current consumer. Callers that need the old behavior can pass `label` explicitly as the third argument.

## Pre-review notes

- Backwards compatible at the publisher library level
- Input validation present (length mismatch errors out)
- Per-camera frame_id logged at boot
- Field-verified (segmentation path)
- ~~No unit test for the new parameter behavior~~ — closed by the refactor + gtest harness in commits `5489f65` and `d612833`. `depthai_marine` gained 4 supplementary tests in the same pass.

## Test plan

- [ ] CI on jazzy passes
- [ ] `colcon test --packages-select depthai_marine sea_surface_segmentation` green (verified locally: 23/23 pass)
- [ ] BizzyBoat launch (PR #95 merged on top) shows segmentation header `frame_id: bizzy/<name>_optical`
- [ ] `tf2_echo` resolves the chain through `bizzy/odom` → optical frame
- [ ] Existing platforms (no `frame_ids` set) still publish `<name>_optical_frame` headers — no regression
- [ ] On any future BizzyBoat config that flips `enable_video=true` or `h265_enable=true` on segmentation: `/image_raw` and `/image_raw/ffmpeg` headers also carry `bizzy/<name>_optical` (was `oak_<name>` previously)

---

**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
