### PR TITLE
Cleanup: expand bounds, drop updated_ flag, document R-channel (#12)

### DIFF
--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -1,4 +1,6 @@
 
+#include <algorithm>
+
 #include "cv_bridge/cv_bridge.hpp"
 #include "geometry_msgs/msg/point_stamped.hpp"
 #include "image_geometry/pinhole_camera_model.hpp"
@@ -72,16 +74,13 @@ public:
     double robot_x, double robot_y, double robot_yaw,
     double* min_x, double* min_y,
     double* max_x, double* max_y) override
-
   {
-   // if(updated_)
-    {
-      *min_x = robot_x - maximum_range_;
-      *min_y = robot_y - maximum_range_;
-      *max_x = robot_x + maximum_range_;
-      *max_y = robot_y + maximum_range_;
-      updated_ = false;
-    }
+    // Expand the master bounds rather than overwrite — clobbering would drop
+    // bounds contributions from earlier layers in the chain (chart_layer, etc.).
+    *min_x = std::min(*min_x, robot_x - maximum_range_);
+    *min_y = std::min(*min_y, robot_y - maximum_range_);
+    *max_x = std::max(*max_x, robot_x + maximum_range_);
+    *max_y = std::max(*max_y, robot_y + maximum_range_);
 
     auto parent = layered_costmap_->getCostmap();
 
@@ -140,8 +139,6 @@ private:
   std::string global_frame_id_;
 
   double update_timeout_ = 0.5;
-
-  bool updated_ = false;
 
   void segmentsCallback(const sensor_msgs::msg::Image::SharedPtr segments_msg)
   {
@@ -203,6 +200,8 @@ private:
                pixel.y >= 0 && pixel.y < static_cast<int>(image->image.rows))
             {
               auto pixel_value = image->image.at<cv::Vec3b>(pixel);
+              // Segmentation channel convention: dominant R marks non-water
+              // (lethal obstacle); dominant G/B marks water (free space).
               if(pixel_value[0] > pixel_value[1] && pixel_value[0] > pixel_value[2])
               {
                 segments_costmap_.setCost(i, j, nav2_costmap_2d::LETHAL_OBSTACLE);
@@ -214,7 +213,6 @@ private:
             }
           }
         }
-        updated_ = true;
       }
       catch(const std::exception& e)
       {


### PR DESCRIPTION
## Summary

Small correctness/cleanup batch from umbrella [#10](https://github.com/rolker/unh_marine_perception/issues/10) — items **C**, **G**, **J**. Independent of the segfault fix landed in [#11](https://github.com/rolker/unh_marine_perception/pull/11); same file, different lines, so the two diffs don't conflict.

## Changes

- **C** (`updateBounds`): `*min_x = robot_x - maximum_range_` → `*min_x = std::min(*min_x, robot_x - maximum_range_)` for each of the four bound assignments. Layer was silently clobbering bounds from earlier layers in the chain (`chart_layer`, etc.), causing the master grid to skip their updates.
- **G** (`updated_` flag): removed entirely. The `// if(updated_)` gate at line 69 was commented out, so the flag was set/cleared but never observed. Bounds-expansion from C handles the no-data case correctly (no contribution when not updated).
- **J** (R-channel test): added a one-line comment explaining the segmentation channel convention (dominant R = non-water = lethal obstacle; dominant G/B = water = free space).

Adds `<algorithm>` include for `std::min`/`std::max`.

## Out of scope

- Items A, B — landed in #11
- Items D, I — architectural restructure (matchSize on every rolling shift, per-cell loop inversion); separate ADR-like discussion
- Items E, F, L — threading hygiene + test coverage; bundled threading-hygiene PR
- Items M, N, O — `segments_to_pointcloud.cpp` and `sea_surface_segmentation.cpp`; filed separately when those files are touched

## Test plan

- [x] `./sensors_ws/build.sh sea_surface_segmentation` clean (one pre-existing `robot_yaw` unused-param warning)
- [x] `./sensors_ws/test.sh sea_surface_segmentation` — 7 tests, 0 failures
- [ ] Field-verified once deployed: bounds-expansion change should be visible as wider master-costmap update regions when other layers are active

Closes #12

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
