### PR TITLE
Fix SeaSurfaceLayer off-by-one in updateCosts loop bounds (#14)

### DIFF
--- a/.agent/work-plans/issue-14/plan.md
+++ b/.agent/work-plans/issue-14/plan.md
@@ -1,0 +1,118 @@
+# Plan: SeaSurfaceLayer segfault with multiple instances
+
+## Issue
+
+https://github.com/rolker/unh_marine_perception/issues/14
+
+## Context
+
+`SeaSurfaceLayer` segfaults in `controller_server` when 4 instances are
+configured in the local costmap (forward/port/starboard/aft). Single-instance
+has been running in the field without a crash. Issue #6's locking fix (PR #11)
+and the bounds-extension fix (PR #13) are in place but did not resolve #14.
+
+Gdb-on-gabby (2026-05-22, boat at the pier) captured a deterministic backtrace
+on the second relaunch cycle:
+
+```
+#0  nav2_costmap_2d::Costmap2D::getCost(unsigned int, unsigned int) const
+#1  sea_surface_layer::SeaSurfaceLayer::updateCosts(this=..., master_grid=...,
+                                                    min_i=…, min_j=0,
+                                                    max_i=1600, max_j=1600)
+       at sea_surface_layer.cpp:107
+       Locals: j=1600  i=1072  lock={...}
+#2  nav2_costmap_2d::LayeredCostmap::updateMap(double, double, double)
+```
+
+The local costmap is `width: 400 m × resolution: 0.25 m` → 1600 × 1600 cells.
+nav2's `LayeredCostmap::updateMap` clamps `max_i`, `max_j` to **equal** the
+costmap's size in cells (half-open `[0, size)`), and `ObstacleLayer::updateCosts`
+loops `i < max_i; ++i`. `SeaSurfaceLayer::updateCosts` instead loops
+`i <= max_i; ++i`, so when the union of all layers' `updateBounds` covers the
+full rolling-window grid, the loop calls `segments_costmap_.getCost(i, 1600)`
+which reads past the buffer end → SIGSEGV.
+
+**Why intermittent + multi-instance-specific:** PR #13 changed the
+`updateBounds` clobber pattern to `std::min/std::max`. With 4 layers + chart_layer
+all contributing bounds, the union reliably reaches the grid edge every cycle.
+With a single SeaSurfaceLayer, max_i often stayed below size_x and the
+off-by-one read landed within mapped heap memory (silently wrong, no crash).
+
+Three sites in `sea_surface_layer.cpp` have the same inclusive-vs-exclusive
+confusion:
+
+1. `updateCosts` outer loop: `i <= max_i` (line 103) — **the crash**.
+2. `updateCosts` inner loop: `j <= max_j` (line 105) — **the crash**.
+3. `segmentsCallback`'s `resetMapToValue(0, 0, count_x_-1, count_y_-1, …)`
+   (line 165) — silent: leaves last row/column uncleared.
+4. `reset()`'s `resetMapToValue(0, 0, count_x_-1, count_y_-1, …)` (line 68) —
+   silent: same.
+
+`Costmap2D::resetMapToValue` takes `(x0, y0, xn, yn)` with `xn`/`yn`
+exclusive (`for (y = y0; y < yn; …)` internally), so the right arguments are
+`(0, 0, count_x_, count_y_, …)`.
+
+## Approach
+
+1. **Fix the two loop bounds in `updateCosts`** — change `<=` to `<`.
+   This is the load-bearing fix that stops the crash.
+2. **Fix the two `resetMapToValue` arg sites** — change `count_x_-1` to
+   `count_x_` (and `count_y_-1` to `count_y_`). The `count_x_ == 0 ||
+   count_y_ == 0` guards remain — they're still needed if `matchSize` hasn't
+   run yet.
+3. **Verification** — field re-cycle on gabby with the 4-layer config that
+   currently crashes ~1-in-3 launches. Per issue #6's pattern (PR #11),
+   field re-test is the meaningful regression check, not a synthetic unit test;
+   the stack trace already names the exact code path and the fix is mechanical.
+   Re-cycle the launch 5+ times on gabby and confirm no SIGSEGV.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `sea_surface_segmentation/src/sea_surface_layer.cpp` | `<=` → `<` in `updateCosts` (2 sites); `count_x_-1` → `count_x_`, `count_y_-1` → `count_y_` in `reset()` and `segmentsCallback`'s `resetMapToValue` (2 sites) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Field verification (cycle-the-launch repro is documented in the PR body) is the regression check. Unit-test scaffolding for a costmap_2d::Layer subclass requires a `LayeredCostmap` fixture + `tf2_ros::Buffer` — adding it for a 5-line mechanical fix is over-scoped. Surfaced as a scope decision, not a silent skip. |
+| Test what breaks | The failure mode (read past buffer end when `max_i == size_x`) was caught in the field with gdb, not by tests. A regression test would need to invoke `updateCosts` directly with grid-edge bounds — that's a follow-up issue if it becomes a recurring problem class. |
+| Only what's needed | No threading-hygiene rework (umbrella #10 items E/F) — the gdb trace is in the `mapUpdateLoop` thread, not a subscription callback. The race hypotheses in #10 are not the cause. |
+| Improve incrementally | Minimum-viable patch for the crash. Leaves the `count_x_ == 0` zero-guards in place. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0008 (ROS 2 conventions) | Yes | The fix aligns this layer with nav2's `[min, max)` half-open bounds convention (matches `ObstacleLayer::updateCosts` and `Costmap2D::resetMapToValue`'s internal iteration). |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `updateCosts` loop bounds | umbrella issue #10 items E/F (threading-race hypotheses) | Yes — close them as "not the cause; see PR" rather than leaving them open as speculative items. |
+| The layer's behavior at grid edges | `seafloor_echoboat_project11`'s 4-layer config (PR #19 / field workaround PR #21) | Yes — once merged, revert PR #21's workaround on gitcloud's `main` so the 4-layer config is the active deployment state. Logged as a follow-up step, not part of this PR. |
+| `segmentsCallback`'s `resetMapToValue` bounds | Nothing else — internal to the layer. | n/a |
+
+## Open Questions
+
+- None at plan stage.
+
+## Estimated Scope
+
+Single PR, ~5-line diff in `sea_surface_layer.cpp`. Field re-cycle (5+ launch
+attempts post-merge on gabby) is the verification step.
+
+## Followups (not in this PR)
+
+- **Close umbrella #10 items E/F** with a note pointing at this PR — the
+  threading races were the wrong hypothesis; the gdb trace shows the crash
+  is in `mapUpdateLoop`, not in `segmentsCallback`. Item L (no regression
+  test) stands.
+- **Revert `seafloor_echoboat_project11#21`** field workaround on gitcloud
+  once gabby's verified 5-cycle-clean post-fix.
+- **Decide on the multi-camera redesign** — per
+  `[[project_sea_surface_layer_one_camera_design]]`, the 4-instance pattern
+  may eventually be replaced by a single layer that ingests N streams. If
+  so, the off-by-one fix is still correct on the way to that redesign.

--- a/.agent/work-plans/issue-14/plan.md
+++ b/.agent/work-plans/issue-14/plan.md
@@ -33,10 +33,15 @@ full rolling-window grid, the loop calls `segments_costmap_.getCost(i, 1600)`
 which reads past the buffer end → SIGSEGV.
 
 **Why intermittent + multi-instance-specific:** PR #13 changed the
-`updateBounds` clobber pattern to `std::min/std::max`. With 4 layers + chart_layer
-all contributing bounds, the union reliably reaches the grid edge every cycle.
-With a single SeaSurfaceLayer, max_i often stayed below size_x and the
-off-by-one read landed within mapped heap memory (silently wrong, no crash).
+`updateBounds` clobber pattern to `std::min/std::max`. With that fix in place,
+`chart_layer`'s wider bounds (set first in the plugin list) now **survive**
+each SeaSurfaceLayer's `updateBounds` call instead of being clobbered. With 4
+SeaSurfaceLayer instances + chart_layer contributing, the surviving union
+reliably reaches the grid edge every cycle. Pre-#13 single-instance had max_i
+often below size_x, so the off-by-one read landed within mapped heap memory
+(silently wrong, no crash). The trigger is "chart_layer bounds survive" more
+than "4 layers" per se — but the 4-layer config is what made it deterministic
+enough to surface in the field.
 
 Three sites in `sea_surface_layer.cpp` have the same inclusive-vs-exclusive
 confusion:
@@ -60,24 +65,42 @@ exclusive (`for (y = y0; y < yn; …)` internally), so the right arguments are
    `count_x_` (and `count_y_-1` to `count_y_`). The `count_x_ == 0 ||
    count_y_ == 0` guards remain — they're still needed if `matchSize` hasn't
    run yet.
-3. **Verification** — field re-cycle on gabby with the 4-layer config that
-   currently crashes ~1-in-3 launches. Per issue #6's pattern (PR #11),
-   field re-test is the meaningful regression check, not a synthetic unit test;
-   the stack trace already names the exact code path and the fix is mechanical.
-   Re-cycle the launch 5+ times on gabby and confirm no SIGSEGV.
+3. **Extract `apply_segments_to_master` as a pure free function** in a new
+   header `src/segments_apply.hpp` — same pattern as `frame_id_resolver.hpp`
+   was extracted for testability. `updateCosts` becomes a thin wrapper that
+   takes the mutex then delegates. The free function operates on two
+   `Costmap2D&` references — no `Layer` base, no `LayeredCostmap`, no TF —
+   so it's directly unit-testable.
+4. **Add gtest cases** in `test/test_segments_apply.cpp`:
+   - **`HalfOpenBoundsRespected`** — call with `max_i < size_x` and verify
+     the row at `max_i` is untouched. Pre-fix `<=` fails this; post-fix
+     passes.
+   - **`GridEdgeBoundsDoesNotCrash`** — call with `max_i == size_x,
+     max_j == size_y`. Pre-fix would read past the buffer end (the
+     SIGSEGV from gabby's gdb trace). Post-fix completes cleanly.
+   - **`NoInformationCellsSkipped`** and **`MasterMaxKept`** — confirm the
+     `NO_INFORMATION` skip and the `cost > master.getCost(i, j)` max-keep
+     semantics are preserved across the refactor.
+5. **Verification** — locally: `colcon test --packages-select
+   sea_surface_segmentation` passes the new tests. In the field on gabby:
+   re-cycle the nav launch 5+ times with the 4-layer config that crashed
+   ~1-in-2 launches in the 2026-05-22 gdb session; confirm no SIGSEGV.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `sea_surface_segmentation/src/sea_surface_layer.cpp` | `<=` → `<` in `updateCosts` (2 sites); `count_x_-1` → `count_x_`, `count_y_-1` → `count_y_` in `reset()` and `segmentsCallback`'s `resetMapToValue` (2 sites) |
+| `sea_surface_segmentation/src/segments_apply.hpp` (new) | Header-only free function `apply_segments_to_master(segments, master, min_i, min_j, max_i, max_j)` with half-open loop bounds (`<`, not `<=`). |
+| `sea_surface_segmentation/src/sea_surface_layer.cpp` | `updateCosts` calls the new free function; `count_x_-1` → `count_x_`, `count_y_-1` → `count_y_` in `reset()` and `segmentsCallback`'s `resetMapToValue` (2 sites). |
+| `sea_surface_segmentation/test/test_segments_apply.cpp` (new) | Four gtest cases covering half-open bounds, grid-edge non-crash, NO_INFORMATION skip, max-keep semantics. |
+| `sea_surface_segmentation/CMakeLists.txt` | Register the new test target (mirroring the `test_frame_id_resolver` pattern). |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| A change includes its consequences | Field verification (cycle-the-launch repro is documented in the PR body) is the regression check. Unit-test scaffolding for a costmap_2d::Layer subclass requires a `LayeredCostmap` fixture + `tf2_ros::Buffer` — adding it for a 5-line mechanical fix is over-scoped. Surfaced as a scope decision, not a silent skip. |
-| Test what breaks | The failure mode (read past buffer end when `max_i == size_x`) was caught in the field with gdb, not by tests. A regression test would need to invoke `updateCosts` directly with grid-edge bounds — that's a follow-up issue if it becomes a recurring problem class. |
+| A change includes its consequences | Pure-function extraction + unit tests land with the fix. Field re-cycle on gabby is documented in the PR body as the in-context verification. |
+| Test what breaks | `HalfOpenBoundsRespected` and `GridEdgeBoundsDoesNotCrash` directly target the failure mode that produced the field SIGSEGV. `NoInformationCellsSkipped`/`MasterMaxKept` pin the refactor's behavioral equivalence. |
 | Only what's needed | No threading-hygiene rework (umbrella #10 items E/F) — the gdb trace is in the `mapUpdateLoop` thread, not a subscription callback. The race hypotheses in #10 are not the cause. |
 | Improve incrementally | Minimum-viable patch for the crash. Leaves the `count_x_ == 0` zero-guards in place. |
 
@@ -92,7 +115,7 @@ exclusive (`for (y = y0; y < yn; …)` internally), so the right arguments are
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
 | `updateCosts` loop bounds | umbrella issue #10 items E/F (threading-race hypotheses) | Yes — close them as "not the cause; see PR" rather than leaving them open as speculative items. |
-| The layer's behavior at grid edges | `seafloor_echoboat_project11`'s 4-layer config (PR #19 / field workaround PR #21) | Yes — once merged, revert PR #21's workaround on gitcloud's `main` so the 4-layer config is the active deployment state. Logged as a follow-up step, not part of this PR. |
+| The layer's behavior at grid edges | `seafloor_echoboat_project11`'s 4-layer config (PR #19 / field workaround PR #21) | Yes — supersede the field workaround once gabby verifies clean: if `seafloor_echoboat_project11#21` is still open, close it without merging and the 4-layer config remains the deployed state; if it merged ahead, file a follow-up PR re-enabling the 3 commented-out layers. Logged as a follow-up step, not part of this PR. |
 | `segmentsCallback`'s `resetMapToValue` bounds | Nothing else — internal to the layer. | n/a |
 
 ## Open Questions
@@ -101,8 +124,9 @@ exclusive (`for (y = y0; y < yn; …)` internally), so the right arguments are
 
 ## Estimated Scope
 
-Single PR, ~5-line diff in `sea_surface_layer.cpp`. Field re-cycle (5+ launch
-attempts post-merge on gabby) is the verification step.
+Single PR. Code: ~25 lines (header + thin `updateCosts` wrapper + 3 one-character
+fixes). Test: ~80 lines (4 focused gtest cases). CMakeLists: +5 lines. Total
+~110-line diff. Field re-cycle on gabby is the in-context verification.
 
 ## Followups (not in this PR)
 
@@ -110,8 +134,10 @@ attempts post-merge on gabby) is the verification step.
   threading races were the wrong hypothesis; the gdb trace shows the crash
   is in `mapUpdateLoop`, not in `segmentsCallback`. Item L (no regression
   test) stands.
-- **Revert `seafloor_echoboat_project11#21`** field workaround on gitcloud
-  once gabby's verified 5-cycle-clean post-fix.
+- **Supersede `seafloor_echoboat_project11#21`** field workaround on gitcloud
+  once gabby's verified 5-cycle-clean post-fix. Exact action depends on PR
+  #21's state at the time: close without merging (if still open) or open a
+  re-enable PR (if it merged ahead).
 - **Decide on the multi-camera redesign** — per
   `[[project_sea_surface_layer_one_camera_design]]`, the 4-instance pattern
   may eventually be replaced by a single layer that ingests N streams. If

--- a/.agent/work-plans/issue-14/plan.md
+++ b/.agent/work-plans/issue-14/plan.md
@@ -72,15 +72,23 @@ exclusive (`for (y = y0; y < yn; …)` internally), so the right arguments are
    `Costmap2D&` references — no `Layer` base, no `LayeredCostmap`, no TF —
    so it's directly unit-testable.
 4. **Add gtest cases** in `test/test_segments_apply.cpp`:
-   - **`HalfOpenBoundsRespected`** — call with `max_i < size_x` and verify
-     the row at `max_i` is untouched. Pre-fix `<=` fails this; post-fix
-     passes.
-   - **`GridEdgeBoundsDoesNotCrash`** — call with `max_i == size_x,
-     max_j == size_y`. Pre-fix would read past the buffer end (the
-     SIGSEGV from gabby's gdb trace). Post-fix completes cleanly.
-   - **`NoInformationCellsSkipped`** and **`MasterMaxKept`** — confirm the
-     `NO_INFORMATION` skip and the `cost > master.getCost(i, j)` max-keep
-     semantics are preserved across the refactor.
+   - **`HalfOpenBoundsRespectedAtOrigin`** — call with `max_i < size_x`
+     from `min_i=0` and verify the row at `max_i` is untouched. Pre-fix
+     `<=` would set those cells, failing the assertion → load-bearing
+     deterministic regression catch for #14.
+   - **`HalfOpenBoundsRespectedOffOrigin`** — same invariant with a
+     non-zero `min_i`, `min_j` (added per review-code feedback to lock
+     down indexing tied to offsets that an origin-anchored test would
+     miss).
+   - **`GridEdgeBoundsCompletes`** — smoke test for the field-crash
+     code path (`max_i == size_x, max_j == size_y`). On a small heap
+     buffer this can pass under the pre-fix `<=` (OOB read often lands
+     in mapped memory), so it documents the field scenario rather
+     than serving as the deterministic catch — `HalfOpenBoundsRespected*`
+     are the load-bearing catches.
+   - **`NoInformationCellsSkipped`** and **`MasterMaxKept`** — confirm
+     the `NO_INFORMATION` skip and the `cost > master.getCost(i, j)`
+     max-keep semantics are preserved across the refactor.
 5. **Verification** — locally: `colcon test --packages-select
    sea_surface_segmentation` passes the new tests. In the field on gabby:
    re-cycle the nav launch 5+ times with the 4-layer config that crashed
@@ -92,7 +100,7 @@ exclusive (`for (y = y0; y < yn; …)` internally), so the right arguments are
 |------|--------|
 | `sea_surface_segmentation/src/segments_apply.hpp` (new) | Header-only free function `apply_segments_to_master(segments, master, min_i, min_j, max_i, max_j)` with half-open loop bounds (`<`, not `<=`). |
 | `sea_surface_segmentation/src/sea_surface_layer.cpp` | `updateCosts` calls the new free function; `count_x_-1` → `count_x_`, `count_y_-1` → `count_y_` in `reset()` and `segmentsCallback`'s `resetMapToValue` (2 sites). |
-| `sea_surface_segmentation/test/test_segments_apply.cpp` (new) | Four gtest cases covering half-open bounds, grid-edge non-crash, NO_INFORMATION skip, max-keep semantics. |
+| `sea_surface_segmentation/test/test_segments_apply.cpp` (new) | Five gtest cases: half-open bounds at origin + off-origin (the deterministic regression catches), grid-edge smoke, NO_INFORMATION skip, max-keep semantics. |
 | `sea_surface_segmentation/CMakeLists.txt` | Register the new test target (mirroring the `test_frame_id_resolver` pattern). |
 
 ## Principles Self-Check
@@ -100,7 +108,7 @@ exclusive (`for (y = y0; y < yn; …)` internally), so the right arguments are
 | Principle | Consideration |
 |---|---|
 | A change includes its consequences | Pure-function extraction + unit tests land with the fix. Field re-cycle on gabby is documented in the PR body as the in-context verification. |
-| Test what breaks | `HalfOpenBoundsRespected` and `GridEdgeBoundsDoesNotCrash` directly target the failure mode that produced the field SIGSEGV. `NoInformationCellsSkipped`/`MasterMaxKept` pin the refactor's behavioral equivalence. |
+| Test what breaks | `HalfOpenBoundsRespectedAtOrigin` (and the off-origin variant) deterministically fail under the pre-fix `<=` loop. `GridEdgeBoundsCompletes` documents the field scenario but isn't load-bearing on small buffers. `NoInformationCellsSkipped`/`MasterMaxKept` pin the refactor's behavioral equivalence. |
 | Only what's needed | No threading-hygiene rework (umbrella #10 items E/F) — the gdb trace is in the `mapUpdateLoop` thread, not a subscription callback. The race hypotheses in #10 are not the cause. |
 | Improve incrementally | Minimum-viable patch for the crash. Leaves the `count_x_ == 0` zero-guards in place. |
 

--- a/.agent/work-plans/issue-14/progress.md
+++ b/.agent/work-plans/issue-14/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 14
+---
+
+# Issue #14 — SeaSurfaceLayer segfault with multiple instances (distinct from #6, same symptom class)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-22 13:55
+**By**: Claude Code Agent (Claude Opus 4.7)
+**Verdict**: approved
+
+**Branch**: `feature/issue-14` at `380aa6d`
+**Mode**: pre-push
+**Depth**: Standard (~300-line multi-file change with a fix + new module + tests)
+**Must-fix**: 0 | **Suggestions**: 1 (declined with rationale)
+
+### Findings
+- [x] (must-fix) `GridEdgeBoundsDoesNotCrash` not a deterministic crash catch on small buffer — `test/test_segments_apply.cpp:55-71` — addressed by rename + clarifying comment + adding `HalfOpenBoundsRespectedOffOrigin` as load-bearing catch
+- [x] (suggestion) Add off-origin window test — `test/test_segments_apply.cpp` — addressed by `HalfOpenBoundsRespectedOffOrigin`
+- [x] (suggestion) Tighten test comments — `test/test_segments_apply.cpp` — addressed
+- [ ] (suggestion declined) Add precondition asserts in `apply_segments_to_master` — `src/segments_apply.hpp:14-30` — nav2's layer code doesn't use them; contract enforced by `Layer::updateCosts` override signature + caller. Re-open as a follow-up issue if misuse becomes a recurring problem class.

--- a/.agent/work-plans/issue-14/progress.md
+++ b/.agent/work-plans/issue-14/progress.md
@@ -20,3 +20,15 @@ issue: 14
 - [x] (suggestion) Add off-origin window test — `test/test_segments_apply.cpp` — addressed by `HalfOpenBoundsRespectedOffOrigin`
 - [x] (suggestion) Tighten test comments — `test/test_segments_apply.cpp` — addressed
 - [ ] (suggestion declined) Add precondition asserts in `apply_segments_to_master` — `src/segments_apply.hpp:14-30` — nav2's layer code doesn't use them; contract enforced by `Layer::updateCosts` override signature + caller. Re-open as a follow-up issue if misuse becomes a recurring problem class.
+
+## External Review
+**Status**: complete
+**When**: 2026-05-22 14:00
+**By**: Claude Code Agent (Claude Opus 4.7)
+
+**PR**: #16 — 1 review (Copilot bot), 0 valid, 0 false positives
+**CI**: all-pass
+
+### Actions
+- [ ] Field verification on gabby (5+ cycle-the-launch with 4-layer config) before merge
+- [ ] After merge: supersede `seafloor_echoboat_project11#21` workaround; close umbrella #10 items E/F as not-the-cause

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -100,6 +100,18 @@ if(BUILD_TESTING)
   target_include_directories(test_frame_id_resolver PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
   )
+
+  # segments_apply.hpp is private to the layer (lives next to
+  # sea_surface_layer.cpp in src/); test target reaches into src/
+  # the same way test_frame_id_resolver does. Links against
+  # nav2_costmap_2d_core for Costmap2D.
+  ament_add_gtest(test_segments_apply test/test_segments_apply.cpp)
+  target_include_directories(test_segments_apply PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+  target_link_libraries(test_segments_apply
+    nav2_costmap_2d::nav2_costmap_2d_core
+  )
 endif()
 
 ament_package()

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -10,6 +10,8 @@
 #include "nav2_costmap_2d/layered_costmap.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
+#include "segments_apply.hpp"
+
 namespace sea_surface_layer
 {
 
@@ -61,11 +63,15 @@ public:
   void reset() override
   {
     std::lock_guard<std::mutex> lock(costmap_mutex_);
-    // Skip when matchSize() has not yet run: count_x_-1 would underflow.
+    // Skip when matchSize() has not yet run: resetMapToValue would still touch
+    // cell (0,0) if count_x_/count_y_ aren't both zero, but the resizeMap call
+    // in matchSize() runs first under normal lifecycle and the guard makes the
+    // invariant explicit.
     if (count_x_ == 0 || count_y_ == 0) {
       return;
     }
-    segments_costmap_.resetMapToValue(0, 0, count_x_-1, count_y_-1, nav2_costmap_2d::NO_INFORMATION);
+    // resetMapToValue uses exclusive (xn, yn) — matches nav2's [min, max) convention.
+    segments_costmap_.resetMapToValue(0, 0, count_x_, count_y_, nav2_costmap_2d::NO_INFORMATION);
   }
 
   bool isClearable() override { return false; }
@@ -100,20 +106,7 @@ public:
     int min_i, int min_j, int max_i, int max_j)  override
   {
     std::lock_guard<std::mutex> lock(costmap_mutex_);
-    for(int i = min_i; i <= max_i; ++i)
-    {
-      for(int j = min_j; j <= max_j; ++j)
-      {
-        unsigned char cost = segments_costmap_.getCost(i, j);
-        if(cost != nav2_costmap_2d::NO_INFORMATION)
-        {
-          if(cost > master_grid.getCost(i, j))
-          {
-            master_grid.setCost(i, j, cost);
-          }
-        }
-      }
-    }
+    apply_segments_to_master(segments_costmap_, master_grid, min_i, min_j, max_i, max_j);
   }
 
   void matchSize() override
@@ -158,11 +151,12 @@ private:
 
         // Defensive guard: matchSize() runs before subscribers are created,
         // but keep the invariant local so future reorderings can't reintroduce
-        // the count_x_-1 underflow.
+        // a zero-size access.
         if (count_x_ == 0 || count_y_ == 0) {
           return;
         }
-        segments_costmap_.resetMapToValue(0, 0, count_x_-1, count_y_-1, nav2_costmap_2d::NO_INFORMATION);
+        // resetMapToValue uses exclusive (xn, yn) — matches nav2's [min, max) convention.
+        segments_costmap_.resetMapToValue(0, 0, count_x_, count_y_, nav2_costmap_2d::NO_INFORMATION);
 
         for(unsigned int i = 0; i < count_x_; i++)
         {

--- a/sea_surface_segmentation/src/segments_apply.hpp
+++ b/sea_surface_segmentation/src/segments_apply.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "nav2_costmap_2d/cost_values.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
+
+namespace sea_surface_layer
+{
+
+// Copy non-NO_INFORMATION cells from `segments` into `master_grid` over the
+// half-open index range [min_i, max_i) × [min_j, max_j), keeping the per-cell
+// maximum cost. Bounds are nav2's convention: `max_i`, `max_j` are exclusive
+// and may equal the grid size — iterating up to and including them reads past
+// the buffer end. (See unh_marine_perception#14.)
+inline void apply_segments_to_master(
+  const nav2_costmap_2d::Costmap2D & segments,
+  nav2_costmap_2d::Costmap2D & master_grid,
+  int min_i, int min_j, int max_i, int max_j)
+{
+  for (int i = min_i; i < max_i; ++i) {
+    for (int j = min_j; j < max_j; ++j) {
+      const unsigned char cost = segments.getCost(i, j);
+      if (cost == nav2_costmap_2d::NO_INFORMATION) {
+        continue;
+      }
+      if (cost > master_grid.getCost(i, j)) {
+        master_grid.setCost(i, j, cost);
+      }
+    }
+  }
+}
+
+}  // namespace sea_surface_layer

--- a/sea_surface_segmentation/test/test_segments_apply.cpp
+++ b/sea_surface_segmentation/test/test_segments_apply.cpp
@@ -23,10 +23,12 @@ Costmap2D make_filled(unsigned int n, unsigned char value)
 
 }  // namespace
 
-// Calling with max_i, max_j BELOW the grid size must leave cells at index
-// max_i and max_j untouched. Pre-fix `<=` would write into them; post-fix `<`
-// does not.
-TEST(ApplySegmentsToMaster, HalfOpenBoundsRespected)
+// Half-open bounds: calling with max_i, max_j BELOW the grid size must leave
+// cells at index max_i and max_j untouched. This is the load-bearing
+// regression test for unh_marine_perception#14 — under the pre-fix `<=`
+// loop, the row at i==max_i and column at j==max_j would be written to,
+// and the FREE_SPACE assertions below would fail deterministically.
+TEST(ApplySegmentsToMaster, HalfOpenBoundsRespectedAtOrigin)
 {
   constexpr unsigned int N = 4;
   Costmap2D segments = make_filled(N, LETHAL_OBSTACLE);
@@ -47,12 +49,41 @@ TEST(ApplySegmentsToMaster, HalfOpenBoundsRespected)
   }
 }
 
-// Regression test for unh_marine_perception#14: with max_i == size_x and
-// max_j == size_y (the LayeredCostmap clamp under a rolling-window costmap
-// where the union of all layers' updateBounds covers the full grid), the
-// loop must stop *before* the buffer end. Pre-fix `<=` read past the end of
-// segments_costmap_.costmap_ → SIGSEGV in the field.
-TEST(ApplySegmentsToMaster, GridEdgeBoundsDoesNotCrash)
+// Same half-open invariant with a window that doesn't touch the origin.
+// Catches an indexing regression tied to a non-zero min_i / min_j that the
+// origin-anchored test above would miss.
+TEST(ApplySegmentsToMaster, HalfOpenBoundsRespectedOffOrigin)
+{
+  constexpr unsigned int N = 5;
+  Costmap2D segments = make_filled(N, LETHAL_OBSTACLE);
+  Costmap2D master = make_filled(N, FREE_SPACE);
+
+  apply_segments_to_master(segments, master, /*min_i=*/1, /*min_j=*/1, /*max_i=*/3, /*max_j=*/3);
+
+  // [1, 3) × [1, 3) should be LETHAL_OBSTACLE (4 cells).
+  for (unsigned int i = 1; i < 3; ++i) {
+    for (unsigned int j = 1; j < 3; ++j) {
+      EXPECT_EQ(master.getCost(i, j), LETHAL_OBSTACLE) << "i=" << i << " j=" << j;
+    }
+  }
+  // Everything outside that window must remain FREE_SPACE.
+  for (unsigned int i = 0; i < N; ++i) {
+    for (unsigned int j = 0; j < N; ++j) {
+      if (i >= 1 && i < 3 && j >= 1 && j < 3) continue;
+      EXPECT_EQ(master.getCost(i, j), FREE_SPACE) << "outside window i=" << i << " j=" << j;
+    }
+  }
+}
+
+// Smoke test for the field crash scenario (max_i == size_x, max_j == size_y).
+// Note: on a small heap-allocated buffer this test can PASS under the pre-fix
+// `<=` because the off-by-one read often lands in mapped heap memory rather
+// than triggering a SIGSEGV. The deterministic crash signal lived in the
+// field repro (1600×1600 grid, gabby 2026-05-22 gdb session); the
+// deterministic regression catch in the unit-test layer is
+// `HalfOpenBoundsRespectedAtOrigin` above. Keep this test as a documented
+// smoke of the field code path.
+TEST(ApplySegmentsToMaster, GridEdgeBoundsCompletes)
 {
   constexpr unsigned int N = 4;
   Costmap2D segments = make_filled(N, LETHAL_OBSTACLE);

--- a/sea_surface_segmentation/test/test_segments_apply.cpp
+++ b/sea_surface_segmentation/test/test_segments_apply.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+
+#include "nav2_costmap_2d/cost_values.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
+
+#include "segments_apply.hpp"
+
+using nav2_costmap_2d::Costmap2D;
+using nav2_costmap_2d::LETHAL_OBSTACLE;
+using nav2_costmap_2d::FREE_SPACE;
+using nav2_costmap_2d::NO_INFORMATION;
+using sea_surface_layer::apply_segments_to_master;
+
+namespace
+{
+
+// Helper: build an N×N Costmap2D initialised to a uniform value.
+Costmap2D make_filled(unsigned int n, unsigned char value)
+{
+  Costmap2D m(n, n, 1.0, 0.0, 0.0, value);
+  return m;
+}
+
+}  // namespace
+
+// Calling with max_i, max_j BELOW the grid size must leave cells at index
+// max_i and max_j untouched. Pre-fix `<=` would write into them; post-fix `<`
+// does not.
+TEST(ApplySegmentsToMaster, HalfOpenBoundsRespected)
+{
+  constexpr unsigned int N = 4;
+  Costmap2D segments = make_filled(N, LETHAL_OBSTACLE);
+  Costmap2D master = make_filled(N, FREE_SPACE);
+
+  apply_segments_to_master(segments, master, /*min_i=*/0, /*min_j=*/0, /*max_i=*/3, /*max_j=*/3);
+
+  // [0, 3) × [0, 3) should be LETHAL_OBSTACLE.
+  for (unsigned int i = 0; i < 3; ++i) {
+    for (unsigned int j = 0; j < 3; ++j) {
+      EXPECT_EQ(master.getCost(i, j), LETHAL_OBSTACLE) << "i=" << i << " j=" << j;
+    }
+  }
+  // Row i==3 and column j==3 must remain FREE_SPACE.
+  for (unsigned int k = 0; k < N; ++k) {
+    EXPECT_EQ(master.getCost(3, k), FREE_SPACE) << "row 3, col " << k;
+    EXPECT_EQ(master.getCost(k, 3), FREE_SPACE) << "col 3, row " << k;
+  }
+}
+
+// Regression test for unh_marine_perception#14: with max_i == size_x and
+// max_j == size_y (the LayeredCostmap clamp under a rolling-window costmap
+// where the union of all layers' updateBounds covers the full grid), the
+// loop must stop *before* the buffer end. Pre-fix `<=` read past the end of
+// segments_costmap_.costmap_ → SIGSEGV in the field.
+TEST(ApplySegmentsToMaster, GridEdgeBoundsDoesNotCrash)
+{
+  constexpr unsigned int N = 4;
+  Costmap2D segments = make_filled(N, LETHAL_OBSTACLE);
+  Costmap2D master = make_filled(N, FREE_SPACE);
+
+  ASSERT_NO_FATAL_FAILURE(
+    apply_segments_to_master(segments, master, 0, 0,
+                             static_cast<int>(N), static_cast<int>(N)));
+
+  // All N×N cells of master should now be LETHAL_OBSTACLE.
+  for (unsigned int i = 0; i < N; ++i) {
+    for (unsigned int j = 0; j < N; ++j) {
+      EXPECT_EQ(master.getCost(i, j), LETHAL_OBSTACLE) << "i=" << i << " j=" << j;
+    }
+  }
+}
+
+// NO_INFORMATION cells in segments must not overwrite master.
+TEST(ApplySegmentsToMaster, NoInformationCellsSkipped)
+{
+  constexpr unsigned int N = 4;
+  Costmap2D segments = make_filled(N, NO_INFORMATION);
+  Costmap2D master = make_filled(N, FREE_SPACE);
+
+  apply_segments_to_master(segments, master, 0, 0, N, N);
+
+  for (unsigned int i = 0; i < N; ++i) {
+    for (unsigned int j = 0; j < N; ++j) {
+      EXPECT_EQ(master.getCost(i, j), FREE_SPACE) << "i=" << i << " j=" << j;
+    }
+  }
+}
+
+// Per-cell max-keep: a lower segments cost must not lower a higher master cost.
+TEST(ApplySegmentsToMaster, MasterMaxKept)
+{
+  constexpr unsigned int N = 2;
+  Costmap2D segments = make_filled(N, FREE_SPACE);
+  Costmap2D master = make_filled(N, LETHAL_OBSTACLE);
+
+  apply_segments_to_master(segments, master, 0, 0, N, N);
+
+  for (unsigned int i = 0; i < N; ++i) {
+    for (unsigned int j = 0; j < N; ++j) {
+      EXPECT_EQ(master.getCost(i, j), LETHAL_OBSTACLE) << "i=" << i << " j=" << j;
+    }
+  }
+}


### PR DESCRIPTION
Closes #14

## Summary

`SeaSurfaceLayer::updateCosts` iterated `i <= max_i` / `j <= max_j`, but nav2's `LayeredCostmap::updateMap` clamps `max_i` to **equal** `size_x` (half-open `[min_i, max_i)` convention — see `ObstacleLayer::updateCosts`). When the union of all layers' `updateBounds` covers the full rolling-window grid (4 SeaSurfaceLayer instances + chart_layer reliably do this after #13's `std::min`/`std::max` change), the loop hits `j == size_y` and `segments_costmap_.getCost(i, size_y)` reads past the buffer → SIGSEGV in `mapUpdateLoop`.

Diagnosis from a live gdb session on gabby (boat on the pier, 2026-05-22):

```
#0  nav2_costmap_2d::Costmap2D::getCost(unsigned int, unsigned int) const
#1  sea_surface_layer::SeaSurfaceLayer::updateCosts(this=...,
                                                    min_j=0,
                                                    max_i=1600, max_j=1600)
       at sea_surface_layer.cpp:107
       Locals: j=1600  i=1072
#2  nav2_costmap_2d::LayeredCostmap::updateMap(double, double, double)
#3  Costmap2DROS::updateMap()
#4  Costmap2DROS::mapUpdateLoop(double)
```

## Changes

- Extract the inner loop into a pure free function `apply_segments_to_master` in a new `src/segments_apply.hpp` (same testability pattern as `frame_id_resolver.hpp`). The function uses half-open bounds (`<`, not `<=`). `updateCosts` becomes a thin wrapper that takes the mutex and delegates.
- Fix the same off-by-one in `reset()` and `segmentsCallback`'s `resetMapToValue` calls (`count_x_ - 1` → `count_x_`, `count_y_ - 1` → `count_y_`). These didn't crash but silently left the last row/column uncleared each cycle.
- Add 5 gtest cases in `test/test_segments_apply.cpp`:
  - `HalfOpenBoundsRespectedAtOrigin` + `HalfOpenBoundsRespectedOffOrigin` — the deterministic regression catches (would fail under pre-fix `<=`).
  - `GridEdgeBoundsCompletes` — documents the field-crash code path; smoke test (small-buffer OOB read can land in mapped memory, so not deterministic).
  - `NoInformationCellsSkipped` + `MasterMaxKept` — pin the refactor's behavioral equivalence.

## Background on the "why intermittent + multi-instance" question

Umbrella issue #10 hypothesised threading races (items E/F) as the cause. The gdb trace shows the crash is in `mapUpdateLoop`, not in `segmentsCallback`, so those hypotheses can be closed as "not the cause; see this PR." The true mechanism is that after #13's `std::min`/`std::max` change, chart_layer's wider bounds now **survive** each SeaSurfaceLayer's `updateBounds` instead of being clobbered. With 4 instances active, the union of bounds reliably covers the full grid each cycle and the inclusive loop trips on the edge.

## Test plan

- [x] `colcon test --packages-select sea_surface_segmentation` — all 5 `ApplySegmentsToMaster` tests pass locally
- [x] `colcon build` clean (no new warnings beyond the pre-existing `unused parameter robot_yaw`)
- [x] Pre-push `/review-code` (Standard tier; Claude + Copilot adversarial both clean post-triage) — see `.agent/work-plans/issue-14/progress.md`
- [ ] **Field re-cycle on gabby (boat on pier, 4-layer config restored)**: 5+ Ctrl-C / relaunch cycles without SIGSEGV. The pre-fix repro was reliable on the 2nd cycle in the 2026-05-22 session.
- [ ] After verify: supersede `seafloor_echoboat_project11#21` (forward-only field workaround) and close `unh_marine_perception#10` items E/F as not-the-cause.

## Plan + progress

- Plan: `.agent/work-plans/issue-14/plan.md`
- Progress: `.agent/work-plans/issue-14/progress.md`

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
