### PR TITLE
[PLAN] Re-architect SeaSurfaceLayer as a single multi-camera fused occupancy layer (temporal persistence + decay)

### DIFF
--- a/.agent/work-plans/issue-19/plan.md
+++ b/.agent/work-plans/issue-19/plan.md
@@ -39,8 +39,14 @@ flip; the seafloor config migration (which activates cross-camera fusion) is the
    (back-compat).
 5. **Thread-safety (#10 E/F)** — guard the shared buffer and per-source camera models against the N
    concurrent camera/camera_info callbacks; fix the `camera_model_` / `count_x_` races.
-6. **Param callback + params (#10 K)** — decay half-life, hit/miss increments, lethal threshold,
-   sources; dynamic-reconfigurable per nav2 convention.
+6. **Live-tunable parameters via a param callback (#10 K)** — register an
+   `OnSetParametersCallbackHandle` so the tuning scalars can be changed at runtime (`ros2 param set`)
+   without a stack restart, for on-the-fly tuning on the water: **decay half-life, hit/miss log-odds
+   increments, lethal threshold, per-source max range**. Applied under the buffer lock — a new
+   threshold reinterprets the existing accumulated buffer immediately; new decay/increment values take
+   effect on the next update. Source list / topics remain configure-time. A unit test asserts the
+   callback actually applies the change (the current layer silently ignores runtime params — the
+   #10-K failure mode).
 7. **Tests (#10 L)** — occupancy buffer (hit raises / miss+decay lowers / threshold / persists across
    a rolling-origin shift / decays to prior over time), waterline-contact + occlusion, two-source
    fusion reinforcing one world cell.
@@ -68,7 +74,7 @@ flip; the seafloor config migration (which activates cross-camera fusion) is the
 | A change includes its consequences | Tests, param docs, and config migration tracked (config is a separate-repo follow-up, owned here) |
 | Test what breaks | Persistence across rolling shift, decay, fusion, flicker rejection, concurrency |
 | Only what's needed | Log-odds is justified by the noise data; no marking modes beyond what the data shows |
-| Human control & transparency | Decay/threshold/sources are params; decay-model choice surfaced for review-plan |
+| Human control & transparency | Tuning scalars (decay/threshold/increments/range) are live-tunable at runtime; decay model decided (log-odds) |
 | Capture decisions | Plan + PR record rationale; #10 flagged this as ADR-like (no project ADR mechanism → captured here) |
 
 ## ADR Compliance
@@ -91,8 +97,8 @@ flip; the seafloor config migration (which activates cross-camera fusion) is the
 
 ## Open Questions
 
-- **Decay/clearing model** — recommend **log-odds occupancy** (robust, principled) over hit/miss+time
-  decay. Defaulting to log-odds in the plan; confirm or veto at review-plan.
+- **Decay/clearing model — DECIDED: log-odds occupancy** (confirmed 2026-05-27). Robust handling of
+  conflicting evidence + graceful clearing. Tuning scalars are live-reconfigurable (phase 6).
 - **Sequencing** — land the perception capability PR first (back-compat single-source), then the
   seafloor config-migration PR to activate cross-camera fusion? (recommended: yes)
 - **Default tuning** — decay half-life, hit/miss increments, lethal threshold: propose conservative

--- a/.agent/work-plans/issue-19/plan.md
+++ b/.agent/work-plans/issue-19/plan.md
@@ -4,8 +4,9 @@
 
 https://github.com/rolker/unh_marine_perception/issues/19
 
-_Revised 2026-05-27 per review-plan (`c72005e`, verdict changes-requested) — see phases 1/3/6/8,
-Consequences, and Open Questions._
+_Revised 2026-05-27 per review-plan (`c72005e`, changes-requested) and follow-up design calls:
+log-odds buffer backed by **grid_map** (resolves the float-buffer rolling risk via `GridMap::move()`);
+#10 H tide-drift confirmed a **non-issue for a floating platform** and dropped._
 
 ## Context
 
@@ -13,8 +14,9 @@ Today: four independent `SeaSurfaceLayer` instances (forward/port/starboard/aft)
 private buffer that `segmentsCallback` wipes (`resetMapToValue` line 159) every frame and re-marks
 only the current FOV. Consequences proven on the 2026-05-26 bag: no obstacle memory (forgotten the
 instant it leaves the FOV — the small-buoy resume), ~50% of dynamic marks flicker even with FOV held
-fixed, and tall obstacles smear false "shadow" lethal cells onto the z=0 plane. Per-camera buffers
-will break the FOV handoff once persistence is added. Overlaps #10 items D, I, H, E/F, L.
+fixed, and tall obstacles smear false "shadow" lethal cells (above-waterline pixels back-projected
+onto the water plane land far beyond the real obstacle). Per-camera buffers will break the FOV handoff
+once persistence is added. Overlaps #10 items D, I, E/F, L (H is resolved as a non-issue — see phase 3).
 
 A tested `is_waterline_contact_pixel` helper + the marking rule already landed (`fe337f6`) against the
 old architecture; the helper/tests carry forward, the integration moves into the rewrite below.
@@ -24,32 +26,36 @@ old architecture; the helper/tests carry forward, the integration moves into the
 Phased, atomic commits. The layer becomes **multi-source-capable but back-compatible with a single
 source**, so this perception PR can land and be reviewed without the config flip. Per review-plan
 (`c72005e`): **this perception PR is _Part of_ #19** (delivers the capability); the dependent seafloor
-config-migration PR activates cross-camera fusion, verifies the handoff AC on bag/sim, and **closes
+config-migration PR activates cross-camera fusion, verifies the handoff AC on bag/sim, and **finalizes
 #19**. *Per-phase invariant:* every commit leaves the layer buildable AND single-source-correct.
 
-1. **Decouple the buffer from the rolling-window resize (#10 D)** — stop wiping on every origin shift.
-   The persistent buffer is the phase-2 **log-odds float array**, so nav2's `Costmap2D::updateOrigin()`
-   (built for `uint8` cost cells) cannot be reused directly: implement an integer-cell partition-copy
-   of the float array keyed to the origin delta, filling newly-exposed border cells with the **prior**
-   (log-odds 0); `resizeMap` only on a true size/resolution change. Fractional-meter shifts quantize to
-   the cell grid — test that evidence survives a *sequence* of sub-cell origin shifts and lands in the
-   correct world cell, not just one clean cell-aligned shift. Load-bearing prerequisite. Addresses #10 D.
-   (Also revisit `isClearable()` — hard-coded `false` today — now that the layer clears via decay.)
-2. **Pure log-odds occupancy buffer** — new header `occupancy_buffer.hpp` (mirrors the
-   `segments_apply.hpp` / `segments_projection.hpp` pure-logic + unit-test pattern): per-cell log-odds,
-   `hit`/`miss` updates, time-based decay toward prior, threshold→LETHAL. Fully unit-tested.
-3. **Inverted projection + waterline-contact + occlusion (#10 I; _partial_ H; shadow)** — per
-   segmentation frame, scan image columns for the waterline contact (`is_waterline_contact_pixel`) and
-   back-project **only the contact** to the ground plane → `hit`; raytrace the free cells between the
+1. **Roll the persistent buffer instead of wiping it (#10 D), via grid_map** — stop the
+   `matchSize()`-on-every-shift wipe. Back the log-odds buffer with a **`grid_map::GridMap`** float
+   layer and roll it with `GridMap::move()`, which shifts by circular-buffer index (no copy), clears
+   only newly-exposed cells, and carries a sub-cell offset so **fractional-meter origin steps** are
+   handled correctly — exactly the rolling-window case `Costmap2D::updateOrigin()` (uint8-only) can't
+   serve. Sync the grid_map position to the master costmap's rolling origin each cycle. Load-bearing
+   prerequisite; addresses #10 D. Test: evidence survives a *sequence* of sub-cell origin shifts and
+   lands in the correct world cell. (Also revisit `isClearable()` — hard-coded `false` today — now that
+   the layer clears via decay.)
+2. **Log-odds occupancy logic** — the buffer is a grid_map float layer (`log_odds`), optionally with a
+   `last_update` layer for time-based decay. Keep the update math (hit/miss, decay toward prior,
+   threshold→LETHAL) in a **pure, unit-tested** helper (`occupancy_buffer.hpp`, mirroring the
+   `segments_apply.hpp` pure-logic + test pattern) operating on the layer data — grid_map owns storage
+   and rolling, the helper owns the evidence math.
+3. **Inverted projection + waterline-contact + occlusion (#10 I; shadow)** — per segmentation frame,
+   scan image columns for the waterline contact (`is_waterline_contact_pixel`) and back-project **only
+   the contact** onto the water surface (z=0 in `map_tide`) → `hit`; raytrace the free cells between the
    camera and the contact → `miss` (clearing); leave the occluded region beyond the contact unobserved
-   (decays, never marked). This needs a **new** pure helper (contact-only projection + camera→contact
+   (decays, never marked). Needs a **new** pure helper (contact-only projection + camera→contact
    free-space raytrace) — `project_obstacle_pixels` emits points for *all* obstacle pixels and is the
-   wrong primitive; it stays unchanged for its other consumer `segments_to_pointcloud.cpp` (the reflex
-   feed), which must be confirmed unaffected. Folds in `fe337f6`; addresses #10 I. **Only _partially_
-   addresses #10 H**: marking at the waterline removes the tall-obstacle smear, but the contact still
-   back-projects to a fixed `plane_z=0`; the `map_tide` vertical-tide-drift component of H is orthogonal
-   — parameterize `plane_z` from the tide frame, or defer it with a note on #10. *Quantization:* on the
-   128×96 mask, contact-range uncertainty is range-dependent (one pixel-row ≈ meters near max range), so
+   wrong primitive; it stays unchanged for its other consumer `segments_to_pointcloud.cpp` (reflex feed),
+   confirmed unaffected. Folds in `fe337f6`; addresses #10 I. **z=0 is correct here**: the boat floats
+   and `map_tide` z=0 tracks the water surface, so projecting onto z=0 *is* projecting onto the real
+   surface at any tide — #10 H's vertical-drift worry does not apply to a floating platform (residuals:
+   TF stamp consistency, already handled via `lookupTransform` at the image stamp; wave heave, a small
+   transient handled by `base_link_level`). Note this on #10. *Quantization:* on the 128×96 mask,
+   contact-range uncertainty is range-dependent (one pixel-row ≈ meters near max range), so
    decay/threshold defaults must tolerate a contact jittering across a few cells without re-creating
    flicker — covered by a tuning note + test.
 4. **Multi-source subscriptions (consolidate 4→1)** — accept a list of camera sources (segmentation +
@@ -67,8 +73,9 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
    the callback applies valid changes AND rejects invalid ones (the current layer silently ignores
    runtime params — the #10-K failure mode).
 7. **Tests (#10 L)** — occupancy buffer (hit raises / miss+decay lowers / threshold / decays to prior
-   over time / **survives a sequence of fractional-meter origin shifts**), waterline-contact +
-   free-space-miss + occlusion, two-source fusion reinforcing one world cell, param validate+apply.
+   over time / **evidence survives a sequence of fractional-meter `grid_map::move()` shifts**),
+   waterline-contact + free-space-miss + occlusion, two-source fusion reinforcing one world cell, param
+   validate+apply.
 8. **Docs + config follow-up (this is what finalizes #19)** — document new params; the dependent seafloor
    `nav2_params.yaml` migration (4 blocks → 1 multi-source) **is the PR that finalizes #19**, since it
    activates cross-camera fusion and is where the handoff AC is verified (bag/sim). Note IzzyBoat parity.
@@ -77,12 +84,13 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 
 | File | Change |
 |------|--------|
-| `sea_surface_segmentation/src/sea_surface_layer.cpp` | Rewrite: multi-source subs, shared persistent log-odds buffer (float-array origin shift, not `updateOrigin`/resize), inverted projection w/ waterline-contact + free-space-miss + occlusion, decay, thread-safe, validating param callback, `isClearable()` revisit |
-| `sea_surface_segmentation/src/occupancy_buffer.hpp` | New pure log-odds buffer (hit/miss/decay/threshold + origin-shift) |
+| `sea_surface_segmentation/src/sea_surface_layer.cpp` | Rewrite: multi-source subs, shared log-odds buffer as a `grid_map` float layer rolled via `move()` and converted to the master via `grid_map_costmap_2d`, inverted projection w/ waterline-contact + free-space-miss + occlusion, decay, thread-safe, validating param callback, `isClearable()` revisit |
+| `sea_surface_segmentation/src/occupancy_buffer.hpp` | New pure log-odds update math (hit/miss/decay/threshold) over a grid_map layer; grid_map owns storage + rolling |
 | `sea_surface_segmentation/src/segments_projection.hpp` | `is_waterline_contact_pixel` (done) + **new** contact-only / free-space-miss projection helper; do NOT repurpose `project_obstacle_pixels` (shared with `segments_to_pointcloud.cpp`) |
-| `sea_surface_segmentation/test/test_occupancy_buffer.cpp` | New: log-odds + decay + fractional-shift persistence tests |
+| `sea_surface_segmentation/package.xml` | Add deps: `grid_map_core`, `grid_map_ros`, `grid_map_costmap_2d` (rosdep-resolvable; already a workspace dep via camp) |
+| `sea_surface_segmentation/test/test_occupancy_buffer.cpp` | New: log-odds + decay + `grid_map::move()` fractional-shift persistence tests |
 | `sea_surface_segmentation/test/test_segments_projection.cpp` | Waterline tests (done) + contact/miss/occlusion + fusion cases |
-| `sea_surface_segmentation/CMakeLists.txt` | Register new test |
+| `sea_surface_segmentation/CMakeLists.txt` | `find_package(grid_map_*)` + link; register new test |
 | `sea_surface_segmentation/README*` / params doc | Document sources, decay, thresholds, runtime-tunable params |
 | seafloor `echoboat_project11/config/nav2_params.yaml` *(follow-up PR — finalizes #19)* | 4 instances → 1 multi-source block (local_costmap only; global_costmap doesn't use the layer) |
 
@@ -90,10 +98,10 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 
 | Principle | Consideration |
 |---|---|
-| Improve incrementally | Phased atomic commits, each buildable + single-source-correct; phase 1 is the riskiest, independently splittable piece |
-| A change includes its consequences | Tests, param docs, shared-header consumer check, and config migration tracked |
+| Improve incrementally | Phased atomic commits, each buildable + single-source-correct; phase 1 (grid_map buffer + rolling) is independently splittable |
+| A change includes its consequences | Tests, param docs, shared-header consumer check, new dependency, and config migration tracked |
 | Test what breaks | Fractional-shift persistence, decay, fusion, flicker rejection, concurrency, param validate/apply |
-| Only what's needed | Log-odds justified by the noise data; no marking modes beyond what the data shows |
+| Only what's needed | Log-odds justified by the noise data; **grid_map reused** (already a workspace dep) rather than hand-rolling buffer rolling math |
 | Human control & transparency | Tuning scalars live-tunable (validated) at runtime; decay model decided (log-odds) |
 | Capture decisions | Plan + PR record rationale; #10 flagged this as ADR-like (no project ADR mechanism → captured here) |
 
@@ -101,7 +109,7 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| 0008 — ROS 2 conventions | Yes | nav2 multi-source idiom + validating `OnSetParametersCallbackHandle`; target Rolling; float-buffer origin shift is custom (uint8 `updateOrigin` doesn't fit) — documented, no deviation needing its own ADR |
+| 0008 — ROS 2 conventions | Yes | nav2 multi-source idiom + validating `OnSetParametersCallbackHandle`; buffer rolling via `grid_map::move()` (idiomatic float-grid primitive) + `grid_map_costmap_2d` bridge; target Rolling; no deviation needing its own ADR |
 | 0001 — Adopt ADRs | Watch | Design rationale + decay-model decision captured in plan/PR (no project-level ADR mechanism in this repo) |
 | 0002 — Worktree isolation | Yes | Work on `feature/issue-19` layer worktree |
 
@@ -111,25 +119,26 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 |---|---|---|
 | `SeaSurfaceLayer` params/behavior | seafloor `nav2_params.yaml` (4→1 multi-source, local_costmap only) | Follow-up PR — **finalizes #19** |
 | ... | IzzyBoat config parity (#120/#181) | Noted for follow-up |
+| Add `grid_map` dependency | `package.xml` + `CMakeLists.txt` (rosdep-resolvable; camp precedent) | Yes |
 | `segments_projection.hpp` (shared header) | confirm `segments_to_pointcloud.cpp` (reflex feed) unaffected by the new helper | Yes |
 | The layer | package README / param docs | Yes |
 | Layer logic | regression tests (#10 L) | Yes |
-| (reconcile #10) | D, I, E/F, L addressed; **H only partially** (shadow, not tide z-drift) | Note in PR + comment on #10 |
+| (reconcile #10) | D, I, E/F, L addressed; **H = non-issue for a floating platform** (note on #10, no code change) | Note in PR + comment on #10 |
 
 ## Open Questions
 
 - **Decay model — DECIDED: log-odds** (2026-05-27). Tuning scalars live-reconfigurable (phase 6).
 - **#19 closure / sequencing — DECIDED** (2026-05-27, review-plan): this perception PR is _Part of_ #19
   (capability); the seafloor config PR activates fusion, verifies the handoff, and finalizes #19.
-- **#10 H tide z-drift — OPEN (non-blocking)**: parameterize `plane_z` from the tide frame in this work,
-  or defer as a separate #10 sub-item? (lean: parameterize if cheap, else defer with a #10 note.)
+- **#10 H tide z-drift — RESOLVED** (2026-05-27): non-issue for a floating boat (z=0 = water surface,
+  tracked by `map_tide`); no `plane_z` work needed; leave a note on #10.
 - **Default tuning** — decay half-life, hit/miss increments, lethal threshold: propose conservative
   defaults, tune on water (non-blocking).
 
 ## Estimated Scope
 
 This perception PR (atomic commits per phase, each buildable + single-source-correct) + a dependent
-`seafloor_echoboat_project11` config PR that **finalizes #19**. Phase 1 (origin-decoupled float log-odds
-buffer + its fractional-shift drift test) is the riskiest, independently reviewable piece — if the
-single perception PR proves unwieldy in review, split phase 1 out first. Bookkeeping handled here; no
-per-ticket overhead for the user.
+`seafloor_echoboat_project11` config PR that **finalizes #19**. Phase 1 (grid_map-backed log-odds buffer
++ `move()`-rolling + fractional-shift test) is the core, independently reviewable piece — de-risked by
+leaning on grid_map rather than hand-rolled buffer math. If the single perception PR proves unwieldy in
+review, split phase 1 out first. Bookkeeping handled here; no per-ticket overhead for the user.

--- a/.agent/work-plans/issue-19/plan.md
+++ b/.agent/work-plans/issue-19/plan.md
@@ -1,0 +1,106 @@
+# Plan: Re-architect SeaSurfaceLayer as a single multi-camera fused occupancy layer (temporal persistence + decay)
+
+## Issue
+
+https://github.com/rolker/unh_marine_perception/issues/19
+
+## Context
+
+Today: four independent `SeaSurfaceLayer` instances (forward/port/starboard/aft), each with a
+private buffer that `segmentsCallback` wipes (`resetMapToValue` line 159) every frame and re-marks
+only the current FOV. Consequences proven on the 2026-05-26 bag: no obstacle memory (forgotten the
+instant it leaves the FOV — the small-buoy resume), ~50% of dynamic marks flicker even with FOV held
+fixed, and tall obstacles smear false "shadow" lethal cells onto the z=0 plane. Per-camera buffers
+will break the FOV handoff once persistence is added. Overlaps #10 items D, I, H, E/F, L.
+
+A tested `is_waterline_contact_pixel` helper + the marking rule already landed (`fe337f6`) against the
+old architecture; the helper/tests carry forward, the integration moves into the rewrite below.
+
+## Approach
+
+Phased, atomic commits on one branch / one PR. The layer becomes **multi-source-capable but
+back-compatible with a single source**, so the code can land without forcing a simultaneous config
+flip; the seafloor config migration (which activates cross-camera fusion) is the dependent follow-up.
+
+1. **Decouple buffer from rolling-window resize (#10 D)** — replace the `matchSize()`-on-every-shift
+   wipe with `updateOrigin()`-style cell-shifting; only `resizeMap` on true size/resolution change.
+   Prerequisite for any persistence. Fixes #10 D.
+2. **Pure log-odds occupancy buffer** — new header `occupancy_buffer.hpp` (mirrors the
+   `segments_apply.hpp` / `segments_projection.hpp` pure-logic + unit-test pattern): per-cell
+   log-odds, `hit`/`miss` updates, time-based decay toward prior, threshold→LETHAL. Fully unit-tested.
+3. **Inverted projection + waterline-contact + occlusion (#10 I, H + shadow)** — per segmentation
+   frame, scan image columns, take the waterline contact (`is_waterline_contact_pixel`), back-project
+   it to the ground plane reusing `project_obstacle_pixels`; contact → `hit`, observed water → `miss`;
+   the occluded region beyond a contact is left unobserved (decays, not marked). Folds in `fe337f6`,
+   fixes #10 I and H.
+4. **Multi-source subscriptions (consolidate 4→1)** — accept a list of camera sources (segmentation +
+   camera_info + per-source `maximum_range`); all feed the one shared world-frame buffer (so an
+   obstacle reinforces the same cell across cameras — the handoff fix). A single source remains valid
+   (back-compat).
+5. **Thread-safety (#10 E/F)** — guard the shared buffer and per-source camera models against the N
+   concurrent camera/camera_info callbacks; fix the `camera_model_` / `count_x_` races.
+6. **Param callback + params (#10 K)** — decay half-life, hit/miss increments, lethal threshold,
+   sources; dynamic-reconfigurable per nav2 convention.
+7. **Tests (#10 L)** — occupancy buffer (hit raises / miss+decay lowers / threshold / persists across
+   a rolling-origin shift / decays to prior over time), waterline-contact + occlusion, two-source
+   fusion reinforcing one world cell.
+8. **Docs + config follow-up** — document new params; migrate seafloor `nav2_params.yaml` (4 blocks →
+   1 multi-source) in a dependent PR (different repo); note IzzyBoat parity.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `sea_surface_segmentation/src/sea_surface_layer.cpp` | Rewrite: multi-source subs, shared persistent buffer (updateOrigin not resize), inverted projection w/ waterline-contact + occlusion, log-odds update, decay, thread-safe, param callback |
+| `sea_surface_segmentation/src/occupancy_buffer.hpp` | New pure log-odds buffer (hit/miss/decay/threshold) |
+| `sea_surface_segmentation/src/segments_projection.hpp` | `is_waterline_contact_pixel` (done); reuse `project_obstacle_pixels` for back-projection |
+| `sea_surface_segmentation/test/test_occupancy_buffer.cpp` | New: log-odds + decay + rolling-shift persistence tests |
+| `sea_surface_segmentation/test/test_segments_projection.cpp` | Waterline tests (done) + fusion/occlusion cases |
+| `sea_surface_segmentation/CMakeLists.txt` | Register new test |
+| `sea_surface_segmentation/README*` / params doc | Document sources, decay, thresholds |
+| seafloor `echoboat_project11/config/nav2_params.yaml` *(follow-up PR, separate repo)* | 4 instances → 1 multi-source block |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Improve incrementally | Phased atomic commits; back-compat single-source lets the code land before the config flip |
+| A change includes its consequences | Tests, param docs, and config migration tracked (config is a separate-repo follow-up, owned here) |
+| Test what breaks | Persistence across rolling shift, decay, fusion, flicker rejection, concurrency |
+| Only what's needed | Log-odds is justified by the noise data; no marking modes beyond what the data shows |
+| Human control & transparency | Decay/threshold/sources are params; decay-model choice surfaced for review-plan |
+| Capture decisions | Plan + PR record rationale; #10 flagged this as ADR-like (no project ADR mechanism → captured here) |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0008 — ROS 2 conventions | Yes | Adopts nav2 ObstacleLayer multi-source idiom + `OnSetParametersCallbackHandle`; target Rolling; no deviation needing its own ADR |
+| 0001 — Adopt ADRs | Watch | Design rationale + decay-model decision captured in plan/PR (no project-level ADR mechanism in this repo) |
+| 0002 — Worktree isolation | Yes | Work on `feature/issue-19` layer worktree |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| `SeaSurfaceLayer` params/behavior | seafloor `nav2_params.yaml` (4→1 multi-source) | Follow-up PR (separate repo, owned here) |
+| ... | IzzyBoat config parity (#120/#181) | Noted for follow-up |
+| The layer | package README / param docs | Yes |
+| Layer logic | regression tests (#10 L) | Yes |
+| (closes #10 items) | reconcile #10: D, I, H, E/F, L addressed | Note in PR + comment on #10 |
+
+## Open Questions
+
+- **Decay/clearing model** — recommend **log-odds occupancy** (robust, principled) over hit/miss+time
+  decay. Defaulting to log-odds in the plan; confirm or veto at review-plan.
+- **Sequencing** — land the perception capability PR first (back-compat single-source), then the
+  seafloor config-migration PR to activate cross-camera fusion? (recommended: yes)
+- **Default tuning** — decay half-life, hit/miss increments, lethal threshold: propose conservative
+  defaults, tune on water.
+
+## Estimated Scope
+
+One PR in `unh_marine_perception` (atomic commits per phase) + one dependent follow-up PR in
+`seafloor_echoboat_project11` for the config migration (separate repo — unavoidable; handled here, no
+bookkeeping for the user). Larger than a typical single PR but kept cohesive per the back-compat
+sequencing; review-plan should confirm it doesn't need a hard split.

--- a/.agent/work-plans/issue-19/plan.md
+++ b/.agent/work-plans/issue-19/plan.md
@@ -4,6 +4,9 @@
 
 https://github.com/rolker/unh_marine_perception/issues/19
 
+_Revised 2026-05-27 per review-plan (`c72005e`, verdict changes-requested) — see phases 1/3/6/8,
+Consequences, and Open Questions._
+
 ## Context
 
 Today: four independent `SeaSurfaceLayer` instances (forward/port/starboard/aft), each with a
@@ -18,70 +21,87 @@ old architecture; the helper/tests carry forward, the integration moves into the
 
 ## Approach
 
-Phased, atomic commits on one branch / one PR. The layer becomes **multi-source-capable but
-back-compatible with a single source**, so the code can land without forcing a simultaneous config
-flip; the seafloor config migration (which activates cross-camera fusion) is the dependent follow-up.
+Phased, atomic commits. The layer becomes **multi-source-capable but back-compatible with a single
+source**, so this perception PR can land and be reviewed without the config flip. Per review-plan
+(`c72005e`): **this perception PR is _Part of_ #19** (delivers the capability); the dependent seafloor
+config-migration PR activates cross-camera fusion, verifies the handoff AC on bag/sim, and **closes
+#19**. *Per-phase invariant:* every commit leaves the layer buildable AND single-source-correct.
 
-1. **Decouple buffer from rolling-window resize (#10 D)** — replace the `matchSize()`-on-every-shift
-   wipe with `updateOrigin()`-style cell-shifting; only `resizeMap` on true size/resolution change.
-   Prerequisite for any persistence. Fixes #10 D.
+1. **Decouple the buffer from the rolling-window resize (#10 D)** — stop wiping on every origin shift.
+   The persistent buffer is the phase-2 **log-odds float array**, so nav2's `Costmap2D::updateOrigin()`
+   (built for `uint8` cost cells) cannot be reused directly: implement an integer-cell partition-copy
+   of the float array keyed to the origin delta, filling newly-exposed border cells with the **prior**
+   (log-odds 0); `resizeMap` only on a true size/resolution change. Fractional-meter shifts quantize to
+   the cell grid — test that evidence survives a *sequence* of sub-cell origin shifts and lands in the
+   correct world cell, not just one clean cell-aligned shift. Load-bearing prerequisite. Fixes #10 D.
+   (Also revisit `isClearable()` — hard-coded `false` today — now that the layer clears via decay.)
 2. **Pure log-odds occupancy buffer** — new header `occupancy_buffer.hpp` (mirrors the
-   `segments_apply.hpp` / `segments_projection.hpp` pure-logic + unit-test pattern): per-cell
-   log-odds, `hit`/`miss` updates, time-based decay toward prior, threshold→LETHAL. Fully unit-tested.
-3. **Inverted projection + waterline-contact + occlusion (#10 I, H + shadow)** — per segmentation
-   frame, scan image columns, take the waterline contact (`is_waterline_contact_pixel`), back-project
-   it to the ground plane reusing `project_obstacle_pixels`; contact → `hit`, observed water → `miss`;
-   the occluded region beyond a contact is left unobserved (decays, not marked). Folds in `fe337f6`,
-   fixes #10 I and H.
+   `segments_apply.hpp` / `segments_projection.hpp` pure-logic + unit-test pattern): per-cell log-odds,
+   `hit`/`miss` updates, time-based decay toward prior, threshold→LETHAL. Fully unit-tested.
+3. **Inverted projection + waterline-contact + occlusion (#10 I; _partial_ H; shadow)** — per
+   segmentation frame, scan image columns for the waterline contact (`is_waterline_contact_pixel`) and
+   back-project **only the contact** to the ground plane → `hit`; raytrace the free cells between the
+   camera and the contact → `miss` (clearing); leave the occluded region beyond the contact unobserved
+   (decays, never marked). This needs a **new** pure helper (contact-only projection + camera→contact
+   free-space raytrace) — `project_obstacle_pixels` emits points for *all* obstacle pixels and is the
+   wrong primitive; it stays unchanged for its other consumer `segments_to_pointcloud.cpp` (the reflex
+   feed), which must be confirmed unaffected. Folds in `fe337f6`; fixes #10 I. **Only _partially_
+   addresses #10 H**: marking at the waterline removes the tall-obstacle smear, but the contact still
+   back-projects to a fixed `plane_z=0`; the `map_tide` vertical-tide-drift component of H is orthogonal
+   — parameterize `plane_z` from the tide frame, or defer it with a note on #10. *Quantization:* on the
+   128×96 mask, contact-range uncertainty is range-dependent (one pixel-row ≈ meters near max range), so
+   decay/threshold defaults must tolerate a contact jittering across a few cells without re-creating
+   flicker — covered by a tuning note + test.
 4. **Multi-source subscriptions (consolidate 4→1)** — accept a list of camera sources (segmentation +
-   camera_info + per-source `maximum_range`); all feed the one shared world-frame buffer (so an
-   obstacle reinforces the same cell across cameras — the handoff fix). A single source remains valid
-   (back-compat).
+   camera_info + per-source `maximum_range`); all feed the one shared world-frame buffer (so an obstacle
+   reinforces the same cell across cameras — the handoff fix). A single source remains valid (back-compat).
 5. **Thread-safety (#10 E/F)** — guard the shared buffer and per-source camera models against the N
    concurrent camera/camera_info callbacks; fix the `camera_model_` / `count_x_` races.
-6. **Live-tunable parameters via a param callback (#10 K)** — register an
-   `OnSetParametersCallbackHandle` so the tuning scalars can be changed at runtime (`ros2 param set`)
-   without a stack restart, for on-the-fly tuning on the water: **decay half-life, hit/miss log-odds
-   increments, lethal threshold, per-source max range**. Applied under the buffer lock — a new
-   threshold reinterprets the existing accumulated buffer immediately; new decay/increment values take
-   effect on the next update. Source list / topics remain configure-time. A unit test asserts the
-   callback actually applies the change (the current layer silently ignores runtime params — the
-   #10-K failure mode).
-7. **Tests (#10 L)** — occupancy buffer (hit raises / miss+decay lowers / threshold / persists across
-   a rolling-origin shift / decays to prior over time), waterline-contact + occlusion, two-source
-   fusion reinforcing one world cell.
-8. **Docs + config follow-up** — document new params; migrate seafloor `nav2_params.yaml` (4 blocks →
-   1 multi-source) in a dependent PR (different repo); note IzzyBoat parity.
+6. **Live-tunable parameters via a param callback (#10 K)** — register an `OnSetParametersCallbackHandle`
+   so the tuning scalars change at runtime (`ros2 param set`) without a stack restart, for on-water
+   tuning: **decay half-life, hit/miss log-odds increments, lethal threshold, per-source max range**.
+   The callback **validates** inputs (reject NaN/negative/out-of-range → `successful=false`) so a
+   fat-fingered set can't silently poison the buffer interpretation, applies under the buffer lock
+   without re-taking it (a new threshold reinterprets the accumulated buffer immediately; new
+   decay/increments take effect next update). Source list / topics stay configure-time. A test asserts
+   the callback applies valid changes AND rejects invalid ones (the current layer silently ignores
+   runtime params — the #10-K failure mode).
+7. **Tests (#10 L)** — occupancy buffer (hit raises / miss+decay lowers / threshold / decays to prior
+   over time / **survives a sequence of fractional-meter origin shifts**), waterline-contact +
+   free-space-miss + occlusion, two-source fusion reinforcing one world cell, param validate+apply.
+8. **Docs + config follow-up (this is what closes #19)** — document new params; the dependent seafloor
+   `nav2_params.yaml` migration (4 blocks → 1 multi-source) **is the PR that closes #19**, since it
+   activates cross-camera fusion and is where the handoff AC is verified (bag/sim). Note IzzyBoat parity.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `sea_surface_segmentation/src/sea_surface_layer.cpp` | Rewrite: multi-source subs, shared persistent buffer (updateOrigin not resize), inverted projection w/ waterline-contact + occlusion, log-odds update, decay, thread-safe, param callback |
-| `sea_surface_segmentation/src/occupancy_buffer.hpp` | New pure log-odds buffer (hit/miss/decay/threshold) |
-| `sea_surface_segmentation/src/segments_projection.hpp` | `is_waterline_contact_pixel` (done); reuse `project_obstacle_pixels` for back-projection |
-| `sea_surface_segmentation/test/test_occupancy_buffer.cpp` | New: log-odds + decay + rolling-shift persistence tests |
-| `sea_surface_segmentation/test/test_segments_projection.cpp` | Waterline tests (done) + fusion/occlusion cases |
+| `sea_surface_segmentation/src/sea_surface_layer.cpp` | Rewrite: multi-source subs, shared persistent log-odds buffer (float-array origin shift, not `updateOrigin`/resize), inverted projection w/ waterline-contact + free-space-miss + occlusion, decay, thread-safe, validating param callback, `isClearable()` revisit |
+| `sea_surface_segmentation/src/occupancy_buffer.hpp` | New pure log-odds buffer (hit/miss/decay/threshold + origin-shift) |
+| `sea_surface_segmentation/src/segments_projection.hpp` | `is_waterline_contact_pixel` (done) + **new** contact-only / free-space-miss projection helper; do NOT repurpose `project_obstacle_pixels` (shared with `segments_to_pointcloud.cpp`) |
+| `sea_surface_segmentation/test/test_occupancy_buffer.cpp` | New: log-odds + decay + fractional-shift persistence tests |
+| `sea_surface_segmentation/test/test_segments_projection.cpp` | Waterline tests (done) + contact/miss/occlusion + fusion cases |
 | `sea_surface_segmentation/CMakeLists.txt` | Register new test |
-| `sea_surface_segmentation/README*` / params doc | Document sources, decay, thresholds |
-| seafloor `echoboat_project11/config/nav2_params.yaml` *(follow-up PR, separate repo)* | 4 instances → 1 multi-source block |
+| `sea_surface_segmentation/README*` / params doc | Document sources, decay, thresholds, runtime-tunable params |
+| seafloor `echoboat_project11/config/nav2_params.yaml` *(follow-up PR — closes #19)* | 4 instances → 1 multi-source block (local_costmap only; global_costmap doesn't use the layer) |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Improve incrementally | Phased atomic commits; back-compat single-source lets the code land before the config flip |
-| A change includes its consequences | Tests, param docs, and config migration tracked (config is a separate-repo follow-up, owned here) |
-| Test what breaks | Persistence across rolling shift, decay, fusion, flicker rejection, concurrency |
-| Only what's needed | Log-odds is justified by the noise data; no marking modes beyond what the data shows |
-| Human control & transparency | Tuning scalars (decay/threshold/increments/range) are live-tunable at runtime; decay model decided (log-odds) |
+| Improve incrementally | Phased atomic commits, each buildable + single-source-correct; phase 1 is the riskiest, independently splittable piece |
+| A change includes its consequences | Tests, param docs, shared-header consumer check, and config migration tracked |
+| Test what breaks | Fractional-shift persistence, decay, fusion, flicker rejection, concurrency, param validate/apply |
+| Only what's needed | Log-odds justified by the noise data; no marking modes beyond what the data shows |
+| Human control & transparency | Tuning scalars live-tunable (validated) at runtime; decay model decided (log-odds) |
 | Capture decisions | Plan + PR record rationale; #10 flagged this as ADR-like (no project ADR mechanism → captured here) |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| 0008 — ROS 2 conventions | Yes | Adopts nav2 ObstacleLayer multi-source idiom + `OnSetParametersCallbackHandle`; target Rolling; no deviation needing its own ADR |
+| 0008 — ROS 2 conventions | Yes | nav2 multi-source idiom + validating `OnSetParametersCallbackHandle`; target Rolling; float-buffer origin shift is custom (uint8 `updateOrigin` doesn't fit) — documented, no deviation needing its own ADR |
 | 0001 — Adopt ADRs | Watch | Design rationale + decay-model decision captured in plan/PR (no project-level ADR mechanism in this repo) |
 | 0002 — Worktree isolation | Yes | Work on `feature/issue-19` layer worktree |
 
@@ -89,24 +109,27 @@ flip; the seafloor config migration (which activates cross-camera fusion) is the
 
 | If we change... | Also update... | Included? |
 |---|---|---|
-| `SeaSurfaceLayer` params/behavior | seafloor `nav2_params.yaml` (4→1 multi-source) | Follow-up PR (separate repo, owned here) |
+| `SeaSurfaceLayer` params/behavior | seafloor `nav2_params.yaml` (4→1 multi-source, local_costmap only) | Follow-up PR — **closes #19** |
 | ... | IzzyBoat config parity (#120/#181) | Noted for follow-up |
+| `segments_projection.hpp` (shared header) | confirm `segments_to_pointcloud.cpp` (reflex feed) unaffected by the new helper | Yes |
 | The layer | package README / param docs | Yes |
 | Layer logic | regression tests (#10 L) | Yes |
-| (closes #10 items) | reconcile #10: D, I, H, E/F, L addressed | Note in PR + comment on #10 |
+| (reconcile #10) | D, I, E/F, L addressed; **H only partially** (shadow, not tide z-drift) | Note in PR + comment on #10 |
 
 ## Open Questions
 
-- **Decay/clearing model — DECIDED: log-odds occupancy** (confirmed 2026-05-27). Robust handling of
-  conflicting evidence + graceful clearing. Tuning scalars are live-reconfigurable (phase 6).
-- **Sequencing** — land the perception capability PR first (back-compat single-source), then the
-  seafloor config-migration PR to activate cross-camera fusion? (recommended: yes)
+- **Decay model — DECIDED: log-odds** (2026-05-27). Tuning scalars live-reconfigurable (phase 6).
+- **#19 closure / sequencing — DECIDED** (2026-05-27, review-plan): this perception PR is _Part of_ #19
+  (capability); the seafloor config PR activates fusion, verifies the handoff, and closes #19.
+- **#10 H tide z-drift — OPEN (non-blocking)**: parameterize `plane_z` from the tide frame in this work,
+  or defer as a separate #10 sub-item? (lean: parameterize if cheap, else defer with a #10 note.)
 - **Default tuning** — decay half-life, hit/miss increments, lethal threshold: propose conservative
-  defaults, tune on water.
+  defaults, tune on water (non-blocking).
 
 ## Estimated Scope
 
-One PR in `unh_marine_perception` (atomic commits per phase) + one dependent follow-up PR in
-`seafloor_echoboat_project11` for the config migration (separate repo — unavoidable; handled here, no
-bookkeeping for the user). Larger than a typical single PR but kept cohesive per the back-compat
-sequencing; review-plan should confirm it doesn't need a hard split.
+This perception PR (atomic commits per phase, each buildable + single-source-correct) + a dependent
+`seafloor_echoboat_project11` config PR that **closes #19**. Phase 1 (origin-decoupled float log-odds
+buffer + its fractional-shift drift test) is the riskiest, independently reviewable piece — if the
+single perception PR proves unwieldy in review, split phase 1 out first. Bookkeeping handled here; no
+per-ticket overhead for the user.

--- a/.agent/work-plans/issue-19/plan.md
+++ b/.agent/work-plans/issue-19/plan.md
@@ -45,10 +45,10 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
    and rolling, the helper owns the evidence math.
 3. **Inverted projection + waterline-contact + occlusion (#10 I; shadow)** — per segmentation frame,
    scan image columns for the waterline contact (`is_waterline_contact_pixel`) and back-project **only
-   the contact** onto the water surface (z=0 in `map_tide`) → `hit`; raytrace the free cells between the
-   camera and the contact → `miss` (clearing); leave the occluded region beyond the contact unobserved
-   (decays, never marked). Needs a **new** pure helper (contact-only projection + camera→contact
-   free-space raytrace) — `project_obstacle_pixels` emits points for *all* obstacle pixels and is the
+   the contact** onto the water surface (z=0 in `map_tide`) → `hit`; water pixels → `miss` (free
+   observations clear where water is positively seen); leave the occluded region beyond the contact
+   unobserved (decays, never marked). Implemented in the **new** `project_observations` helper —
+   `project_obstacle_pixels` emits points for *all* obstacle pixels and is the
    wrong primitive; it stays unchanged for its other consumer `segments_to_pointcloud.cpp` (reflex feed),
    confirmed unaffected. Folds in `fe337f6`; addresses #10 I. **z=0 is correct here**: the boat floats
    and `map_tide` z=0 tracks the water surface, so projecting onto z=0 *is* projecting onto the real
@@ -145,6 +145,13 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
   `${grid_map_core_INCLUDE_DIRS}` var is empty under the modern target export; pull the path from the
   imported target (`get_target_property(... INTERFACE_INCLUDE_DIRECTORIES)`) and `include_directories()`
   it globally. The layer-integration phase must keep this.
+- **Free-space clearing (phase 3):** chose **water-pixel-as-free** (`miss` at the ground point of each
+  segmented water pixel) over an explicit camera→contact Bresenham raytrace. It's more conservative —
+  it only clears cells the camera *positively observes as water*, not every cell along the ray
+  (which would clear unobserved cells too) — and falls out of the same per-pixel back-projection loop.
+- **Layer verification (phase 3):** the buffer and `project_observations` are unit-tested; the live
+  layer wiring (TF→pose, rolling, threshold-to-master) is verified by the bag→costmap→video utility
+  (see #19 follow-up) on the 2026-05-26 bag before the boat — the layer itself has no unit test.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-19/plan.md
+++ b/.agent/work-plans/issue-19/plan.md
@@ -8,6 +8,13 @@ _Revised 2026-05-27 per review-plan (`c72005e`, changes-requested) and follow-up
 log-odds buffer backed by **grid_map** (resolves the float-buffer rolling risk via `GridMap::move()`);
 #10 H tide-drift confirmed a **non-issue for a floating platform** and dropped._
 
+_Revised again 2026-05-27 after offline review on the 2026-05-26 bag (episode #21): (1) **phase 3
+projection corrected forward → inverse** (the committed `project_observations` was a regression vs the
+pre-#19 inverse layer — forward leaves gaps/speckle and never reaches lethal); (2) **new global-costmap
+propagation** so the planner can route around buoys — `SeaSurfaceLayer` publishes its contribution and a
+thin `SeaSurfaceRelayLayer` feeds the global costmap (publish-and-relay, mirroring the S57 producer/
+consumer pattern). See the new section + Open Questions._
+
 ## Context
 
 Today: four independent `SeaSurfaceLayer` instances (forward/port/starboard/aft), each with a
@@ -43,21 +50,32 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
    threshold→LETHAL) in a **pure, unit-tested** helper (`occupancy_buffer.hpp`, mirroring the
    `segments_apply.hpp` pure-logic + test pattern) operating on the layer data — grid_map owns storage
    and rolling, the helper owns the evidence math.
-3. **Inverted projection + waterline-contact + occlusion (#10 I; shadow)** — per segmentation frame,
-   scan image columns for the waterline contact (`is_waterline_contact_pixel`) and back-project **only
-   the contact** onto the water surface (z=0 in `map_tide`) → `hit`; water pixels → `miss` (free
-   observations clear where water is positively seen); leave the occluded region beyond the contact
-   unobserved (decays, never marked). Implemented in the **new** `project_observations` helper —
-   `project_obstacle_pixels` emits points for *all* obstacle pixels and is the
-   wrong primitive; it stays unchanged for its other consumer `segments_to_pointcloud.cpp` (reflex feed),
-   confirmed unaffected. Folds in `fe337f6`; addresses #10 I. **z=0 is correct here**: the boat floats
-   and `map_tide` z=0 tracks the water surface, so projecting onto z=0 *is* projecting onto the real
-   surface at any tide — #10 H's vertical-drift worry does not apply to a floating platform (residuals:
-   TF stamp consistency, already handled via `lookupTransform` at the image stamp; wave heave, a small
-   transient handled by `base_link_level`). Note this on #10. *Quantization:* on the 128×96 mask,
-   contact-range uncertainty is range-dependent (one pixel-row ≈ meters near max range), so
-   decay/threshold defaults must tolerate a contact jittering across a few cells without re-creating
-   flicker — covered by a tuning note + test.
+3. **Projection: INVERSE (cell→pixel) + waterline-contact + occlusion (#10 I; shadow)** — for each
+   world cell in the buffer window, project the cell's ground point (z=0 in `map_tide`) into the camera
+   and classify it by the pixel it lands on: a cell whose pixel is its column's **waterline contact**
+   (`is_waterline_contact_pixel`) → `hit`; a cell seeing **water** → `miss` (free where water is
+   positively observed); a cell behind the contact (projecting to an above-contact body pixel) → left
+   **unobserved** (occluded; decays, never marked). This is the **inverse** direction the pre-#19 layer
+   used (iterate cells, sample the covering pixel): one large/distant pixel fills **every cell in its
+   footprint** (no gaps), and the search is **range-bounded to the window** (a near-horizon pixel can't
+   smear past the window edge). `project_obstacle_pixels` stays unchanged for its other consumer
+   `segments_to_pointcloud.cpp` (reflex feed). **z=0 is correct here** (floating boat; `map_tide` z=0
+   tracks the surface — #10 H non-issue). Add a per-camera **FOV frustum cull** so iterating window
+   cells × cameras stays cheap at ~10 Hz × 4 cameras.
+
+   > **Regression caught 2026-05-27 — this phase must change.** The first phase-3 implementation
+   > (`f10666c`) drifted to **forward** per-pixel projection (`project_observations`: each pixel → one
+   > world point → one cell), despite this phase's "inverted projection / #10-I loop-inversion" intent.
+   > Forward leaves **gaps** at range, makes **lone jittery hits** that never reach the 2-hit lethal
+   > threshold, and forward-projects near-horizon pixels to far cells (the speckle "ring"). Offline A/B
+   > on the 2026-05-26 bag (episode #21, 2.0 m/s approach→STOP) measured **forward 0.1 % lethal vs
+   > inverse 3.2 %** (live fused costmap 6.8 %); inverse produces a coherent obstacle footprint that
+   > tracks the live costmap through the maneuver while forward stays incoherent speckle. **Fix: restore
+   > inverse projection feeding the buffer**, keeping contact-only marking (the shadow fix lived in the
+   > inverse loop in `fe337f6`, so both are compatible). Verified offline by the `bag_to_costmap_video`
+   > forward-vs-inverse mosaic before the boat. **Note:** the layer **currently deployed on bizzy**
+   > (4 instances, pre-#19, via the bizzy overlay) is **inverse**, so the live costmap in the A/B already
+   > reflects inverse segmentation — the forward rewrite would regress vs the behaviour running today.
 4. **Multi-source subscriptions (consolidate 4→1)** — accept a list of camera sources (segmentation +
    camera_info + per-source `maximum_range`); all feed the one shared world-frame buffer (so an obstacle
    reinforces the same cell across cameras — the handoff fix). A single source remains valid (back-compat).
@@ -80,19 +98,51 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
    `nav2_params.yaml` migration (4 blocks → 1 multi-source) **is the PR that finalizes #19**, since it
    activates cross-camera fusion and is where the handoff AC is verified (bag/sim). Note IzzyBoat parity.
 
+## Global-costmap propagation — planner buoy-avoidance (new, 2026-05-27)
+
+**Problem surfaced during the #21 review.** The controller (`marine_nav_crabbing_path_follower::CrabbingPathFollower`)
+does **not** consult the costmap, and the global planner (`SmacPlannerHybrid`) plans on the **global**
+costmap — which carries charted obstacles (`s57_layer`) + inflation but **no segmentation**. So an
+uncharted buoy the cameras detect never reaches the planner; today the local costmap (where the
+sea-surface layer lives) is effectively **operator-display-only** for planning. For the planner to route
+around buoys, the detection must reach the **global** costmap. (`local_costmap` and `global_costmap` are
+separate `Costmap2DROS` instances — in `controller_server` and `planner_server` — with independent layer
+plugin instances; a layer in one is not in the other.)
+
+**Decision — publish-and-relay (mirrors the existing S57 producer/consumer pattern).** `s57_grids`
+already produces chart `grid_map`s once and both costmaps' `s57_layer` instances subscribe; copy that:
+- The local `SeaSurfaceLayer` **publishes its own contribution** (the grid_map log-odds buffer,
+  thresholded) on a dedicated topic — cheap, since the buffer is already a `grid_map::GridMap`. It must
+  publish the **layer's contribution, NOT the fused local master** (that would double-count `s57_layer`
+  and import local's 150 m inflation into global).
+- A new **thin `SeaSurfaceRelayLayer`** (subscribe-and-rasterize, like `s57_layer` minus dataset
+  discovery) is added to the **global** costmap, ordered **before** `inflation_layer` so the planner
+  inflates the buoys. (Stock `nav2_costmap_2d::StaticLayer` composes poorly with a **rolling** global
+  costmap — `global_costmap` is `rolling_window: true` — so a small custom relay layer is safer.)
+- Projection + persistence run **once** (in the local layer); both costmaps consume the result. No
+  second projection, no second buffer.
+
+**Tradeoff (accepted).** The producer is coupled to `controller_server`'s lifecycle (restart → global
+loses buoys until republish). Promotable to a standalone producer node later (full S57-style split)
+without changing the relay side.
+
+**Scope.** This is **new work beyond the original #19 split** and is cross-repo (new relay layer here +
+global-costmap config in seafloor), but **all tracked under #19** (decided 2026-05-27 — no separate issue).
+
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `sea_surface_segmentation/src/sea_surface_layer.cpp` | Rewrite: multi-source subs, shared log-odds buffer as a `grid_map` float layer rolled via `move()` and converted to the master via `grid_map_costmap_2d`, inverted projection w/ waterline-contact + free-space-miss + occlusion, decay, thread-safe, validating param callback, `isClearable()` revisit |
+| `sea_surface_segmentation/src/sea_surface_layer.cpp` | Rewrite: multi-source subs, shared log-odds buffer as a `grid_map` float layer rolled via `move()` and converted to the master via `grid_map_costmap_2d`, **INVERSE (cell→pixel)** projection w/ waterline-contact + free-space-miss + occlusion + FOV frustum cull, decay, thread-safe, validating param callback, `isClearable()` revisit, **publish the buffer's contribution as a `grid_map`/`OccupancyGrid` topic** (for the global relay) |
 | `sea_surface_segmentation/src/occupancy_buffer.hpp` | New pure log-odds update math (hit/miss/decay/threshold) over a grid_map layer; grid_map owns storage + rolling |
-| `sea_surface_segmentation/src/segments_projection.hpp` | `is_waterline_contact_pixel` (done) + **new** contact-only / free-space-miss projection helper; do NOT repurpose `project_obstacle_pixels` (shared with `segments_to_pointcloud.cpp`) |
+| `sea_surface_segmentation/src/segments_projection.hpp` | `is_waterline_contact_pixel` + per-column contact map (image-space primitives the inverse loop samples); do NOT repurpose `project_obstacle_pixels` (shared with `segments_to_pointcloud.cpp`). **Drop the forward `project_observations` from the layer's path** (keep/relocate any reuse for the offline tool) |
+| `sea_surface_segmentation/` — new `SeaSurfaceRelayLayer` | New thin costmap layer: subscribe to the published contribution grid and rasterize into the costmap. Added to the **global** costmap before inflation. Mirrors `s57_layer`'s subscribe-and-rasterize. |
 | `sea_surface_segmentation/package.xml` | Add deps: `grid_map_core`, `grid_map_ros`, `grid_map_costmap_2d` (rosdep-resolvable; already a workspace dep via camp) |
 | `sea_surface_segmentation/test/test_occupancy_buffer.cpp` | New: log-odds + decay + `grid_map::move()` fractional-shift persistence tests |
 | `sea_surface_segmentation/test/test_segments_projection.cpp` | Waterline tests (done) + contact/miss/occlusion + fusion cases |
 | `sea_surface_segmentation/CMakeLists.txt` | `find_package(grid_map_*)` + link; register new test |
 | `sea_surface_segmentation/README*` / params doc | Document sources, decay, thresholds, runtime-tunable params |
-| seafloor `echoboat_project11/config/nav2_params.yaml` *(follow-up PR — finalizes #19)* | 4 instances → 1 multi-source block (local_costmap only; global_costmap doesn't use the layer) |
+| seafloor / bizzy instance config *(follow-up PR — finalizes #19)* | The 4 `SeaSurfaceLayer` instances are **already live** in bizzy's local costmap via `unh_echoboats_project11/bizzyboat_project11/config/nav2_overlay.yaml` (re-enabled by seafloor **#18, closed** — running the pre-#19 **inverse** code). Migrate local: 4 instances → 1 multi-source `SeaSurfaceLayer`. Add `SeaSurfaceRelayLayer` to the **global** costmap (before `inflation_layer`) — gets buoys in front of the planner. Note IzzyBoat parity. |
 
 ## Principles Self-Check
 
@@ -124,6 +174,9 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 | The layer | package README / param docs | Yes |
 | Layer logic | regression tests (#10 L) | Yes |
 | (reconcile #10) | D, I, E/F, L addressed; **H = non-issue for a floating platform** (note on #10, no code change) | Note in PR + comment on #10 |
+| Layer publishes its contribution | new topic; `SeaSurfaceRelayLayer` consumes it in the **global** costmap (before inflation) | New scope (publish-and-relay) |
+| Global costmap gains buoys | seafloor `nav2_params.yaml` **global_costmap** plugins (+relay layer); planner now routes around detections | Cross-repo (seafloor) |
+| Producer coupled to `controller_server` | if it restarts, global loses buoys until republish; promote to standalone node if it bites | Accepted tradeoff |
 
 ## Open Questions
 
@@ -133,7 +186,15 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 - **#10 H tide z-drift — RESOLVED** (2026-05-27): non-issue for a floating boat (z=0 = water surface,
   tracked by `map_tide`); no `plane_z` work needed; leave a note on #10.
 - **Default tuning** — decay half-life, hit/miss increments, lethal threshold: propose conservative
-  defaults, tune on water (non-blocking).
+  defaults, tune on water (non-blocking). Revisit *after* the inverse-projection fix, not before.
+- **Projection direction — DECIDED: inverse (cell→pixel)** (2026-05-27). The committed forward
+  `project_observations` is a regression vs the pre-#19 inverse layer; offline A/B on the 2026-05-26
+  bag confirmed inverse fills footprints where forward leaves speckle. Phase 3 restores inverse.
+- **Buoys to the planner — DECIDED: publish-and-relay** (2026-05-27). Local `SeaSurfaceLayer` publishes
+  its contribution; a thin `SeaSurfaceRelayLayer` feeds the global costmap (before inflation). Producer
+  stays in-layer for now (coupled to `controller_server`); standalone node is a later option.
+- **Global relay scope — DECIDED: all in #19** (2026-05-27, user). No separate issue; the relay layer +
+  seafloor global config land under #19 alongside the inverse fix and local migration.
 
 ## Implementation Notes
 
@@ -145,13 +206,21 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
   `${grid_map_core_INCLUDE_DIRS}` var is empty under the modern target export; pull the path from the
   imported target (`get_target_property(... INTERFACE_INCLUDE_DIRECTORIES)`) and `include_directories()`
   it globally. The layer-integration phase must keep this.
-- **Free-space clearing (phase 3):** chose **water-pixel-as-free** (`miss` at the ground point of each
-  segmented water pixel) over an explicit camera→contact Bresenham raytrace. It's more conservative —
-  it only clears cells the camera *positively observes as water*, not every cell along the ray
-  (which would clear unobserved cells too) — and falls out of the same per-pixel back-projection loop.
-- **Layer verification (phase 3):** the buffer and `project_observations` are unit-tested; the live
-  layer wiring (TF→pose, rolling, threshold-to-master) is verified by the bag→costmap→video utility
-  (see #19 follow-up) on the 2026-05-26 bag before the boat — the layer itself has no unit test.
+- **Free-space clearing (phase 3):** **water-as-free** — a cell that projects to a water pixel gets a
+  `miss`. Conservative (only clears cells the camera *positively observes as water*, not whole rays),
+  and in the inverse loop it falls out of the same per-cell classification as the hit/occlusion cases.
+- **Layer verification (phase 3):** the buffer is unit-tested; the live layer wiring (TF→pose, rolling,
+  projection, threshold-to-master) is verified offline by the `bag_to_costmap_video` tool. Today it
+  renders a two-row mosaic — top: 4 segmentation tiles (port·fwd·stbd·aft); bottom: live boat costmap |
+  OURS (inverse). An earlier four-panel version added a NEW-forward panel for the A/B that surfaced the
+  forward-projection regression on the 2026-05-26 bag (episode #21); the forward panel has been dropped
+  since the A/B is settled, but the diff lives in git history if it ever needs reproducing. The forward
+  `project_observations` still exists in `segments_projection.hpp` for the reflex-pointcloud consumer;
+  it will be removed from the layer's projection path in the phase-3 implementation commit. The layer
+  itself has no unit test, so this offline render is the gate before the boat.
+- **Inverse cost (phase 3):** iterating window cells × cameras is heavier than forward per-pixel; bound
+  it with an early behind-camera reject + a per-camera FOV frustum cull. The buffer window (±half-extent)
+  naturally caps range, so the far-horizon speckle ring cannot form.
 
 ## Estimated Scope
 
@@ -160,3 +229,10 @@ This perception PR (atomic commits per phase, each buildable + single-source-cor
 + `move()`-rolling + fractional-shift test) is the core, independently reviewable piece — de-risked by
 leaning on grid_map rather than hand-rolled buffer math. If the single perception PR proves unwieldy in
 review, split phase 1 out first. Bookkeeping handled here; no per-ticket overhead for the user.
+
+**Added 2026-05-27:** phase 3 now restores **inverse** projection (was a forward-projection regression),
+and the **global-costmap propagation** (publish-and-relay: layer publisher + `SeaSurfaceRelayLayer`) is
+new, cross-repo scope (with seafloor) **but all tracked under #19** — no separate issue. The
+`bag_to_costmap_video` offline tool is the verification harness; it now ships the inverse-only mosaic
+(forward A/B is settled and dropped from the tool — diff in git history). Sibling diagnostic tracked
+separately as [#21](https://github.com/rolker/unh_marine_perception/issues/21).

--- a/.agent/work-plans/issue-19/plan.md
+++ b/.agent/work-plans/issue-19/plan.md
@@ -33,7 +33,7 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
    of the float array keyed to the origin delta, filling newly-exposed border cells with the **prior**
    (log-odds 0); `resizeMap` only on a true size/resolution change. Fractional-meter shifts quantize to
    the cell grid — test that evidence survives a *sequence* of sub-cell origin shifts and lands in the
-   correct world cell, not just one clean cell-aligned shift. Load-bearing prerequisite. Fixes #10 D.
+   correct world cell, not just one clean cell-aligned shift. Load-bearing prerequisite. Addresses #10 D.
    (Also revisit `isClearable()` — hard-coded `false` today — now that the layer clears via decay.)
 2. **Pure log-odds occupancy buffer** — new header `occupancy_buffer.hpp` (mirrors the
    `segments_apply.hpp` / `segments_projection.hpp` pure-logic + unit-test pattern): per-cell log-odds,
@@ -45,7 +45,7 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
    (decays, never marked). This needs a **new** pure helper (contact-only projection + camera→contact
    free-space raytrace) — `project_obstacle_pixels` emits points for *all* obstacle pixels and is the
    wrong primitive; it stays unchanged for its other consumer `segments_to_pointcloud.cpp` (the reflex
-   feed), which must be confirmed unaffected. Folds in `fe337f6`; fixes #10 I. **Only _partially_
+   feed), which must be confirmed unaffected. Folds in `fe337f6`; addresses #10 I. **Only _partially_
    addresses #10 H**: marking at the waterline removes the tall-obstacle smear, but the contact still
    back-projects to a fixed `plane_z=0`; the `map_tide` vertical-tide-drift component of H is orthogonal
    — parameterize `plane_z` from the tide frame, or defer it with a note on #10. *Quantization:* on the
@@ -69,8 +69,8 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 7. **Tests (#10 L)** — occupancy buffer (hit raises / miss+decay lowers / threshold / decays to prior
    over time / **survives a sequence of fractional-meter origin shifts**), waterline-contact +
    free-space-miss + occlusion, two-source fusion reinforcing one world cell, param validate+apply.
-8. **Docs + config follow-up (this is what closes #19)** — document new params; the dependent seafloor
-   `nav2_params.yaml` migration (4 blocks → 1 multi-source) **is the PR that closes #19**, since it
+8. **Docs + config follow-up (this is what finalizes #19)** — document new params; the dependent seafloor
+   `nav2_params.yaml` migration (4 blocks → 1 multi-source) **is the PR that finalizes #19**, since it
    activates cross-camera fusion and is where the handoff AC is verified (bag/sim). Note IzzyBoat parity.
 
 ## Files to Change
@@ -84,7 +84,7 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 | `sea_surface_segmentation/test/test_segments_projection.cpp` | Waterline tests (done) + contact/miss/occlusion + fusion cases |
 | `sea_surface_segmentation/CMakeLists.txt` | Register new test |
 | `sea_surface_segmentation/README*` / params doc | Document sources, decay, thresholds, runtime-tunable params |
-| seafloor `echoboat_project11/config/nav2_params.yaml` *(follow-up PR — closes #19)* | 4 instances → 1 multi-source block (local_costmap only; global_costmap doesn't use the layer) |
+| seafloor `echoboat_project11/config/nav2_params.yaml` *(follow-up PR — finalizes #19)* | 4 instances → 1 multi-source block (local_costmap only; global_costmap doesn't use the layer) |
 
 ## Principles Self-Check
 
@@ -109,7 +109,7 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 
 | If we change... | Also update... | Included? |
 |---|---|---|
-| `SeaSurfaceLayer` params/behavior | seafloor `nav2_params.yaml` (4→1 multi-source, local_costmap only) | Follow-up PR — **closes #19** |
+| `SeaSurfaceLayer` params/behavior | seafloor `nav2_params.yaml` (4→1 multi-source, local_costmap only) | Follow-up PR — **finalizes #19** |
 | ... | IzzyBoat config parity (#120/#181) | Noted for follow-up |
 | `segments_projection.hpp` (shared header) | confirm `segments_to_pointcloud.cpp` (reflex feed) unaffected by the new helper | Yes |
 | The layer | package README / param docs | Yes |
@@ -120,7 +120,7 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 
 - **Decay model — DECIDED: log-odds** (2026-05-27). Tuning scalars live-reconfigurable (phase 6).
 - **#19 closure / sequencing — DECIDED** (2026-05-27, review-plan): this perception PR is _Part of_ #19
-  (capability); the seafloor config PR activates fusion, verifies the handoff, and closes #19.
+  (capability); the seafloor config PR activates fusion, verifies the handoff, and finalizes #19.
 - **#10 H tide z-drift — OPEN (non-blocking)**: parameterize `plane_z` from the tide frame in this work,
   or defer as a separate #10 sub-item? (lean: parameterize if cheap, else defer with a #10 note.)
 - **Default tuning** — decay half-life, hit/miss increments, lethal threshold: propose conservative
@@ -129,7 +129,7 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 ## Estimated Scope
 
 This perception PR (atomic commits per phase, each buildable + single-source-correct) + a dependent
-`seafloor_echoboat_project11` config PR that **closes #19**. Phase 1 (origin-decoupled float log-odds
+`seafloor_echoboat_project11` config PR that **finalizes #19**. Phase 1 (origin-decoupled float log-odds
 buffer + its fractional-shift drift test) is the riskiest, independently reviewable piece — if the
 single perception PR proves unwieldy in review, split phase 1 out first. Bookkeeping handled here; no
 per-ticket overhead for the user.

--- a/.agent/work-plans/issue-19/plan.md
+++ b/.agent/work-plans/issue-19/plan.md
@@ -135,6 +135,17 @@ config-migration PR activates cross-camera fusion, verifies the handoff AC on ba
 - **Default tuning** — decay half-life, hit/miss increments, lethal threshold: propose conservative
   defaults, tune on water (non-blocking).
 
+## Implementation Notes
+
+- **grid_map CMake gotcha (phase 1):** `grid_map_core`'s extras inject
+  `-DEIGEN_*_PLUGIN="grid_map_core/eigen_plugins/..."` via **global `add_definitions`** at
+  `find_package` time, so *every* TU compiled afterward needs grid_map_core's include dir — not just
+  targets that link `grid_map_core::grid_map_core` (else unrelated targets like
+  `segments_to_pointcloud` fail with "FunctorsPlugin.hpp: No such file"). The legacy
+  `${grid_map_core_INCLUDE_DIRS}` var is empty under the modern target export; pull the path from the
+  imported target (`get_target_property(... INTERFACE_INCLUDE_DIRECTORIES)`) and `include_directories()`
+  it globally. The layer-integration phase must keep this.
+
 ## Estimated Scope
 
 This perception PR (atomic commits per phase, each buildable + single-source-correct) + a dependent

--- a/.agent/work-plans/issue-19/progress.md
+++ b/.agent/work-plans/issue-19/progress.md
@@ -27,3 +27,21 @@ idiom.
 - [ ] Settle the decay-model open question (log-odds vs hit/miss+time-decay) before plan-task locks the design; record the choice in the issue
 - [ ] Tests targeting persistence/decay, multi-camera fusion, and concurrency (satisfies #10 L)
 - [ ] Track cross-repo config consequence: seafloor_echoboat_project11 nav2_params.yaml (4 blocks → 1 multi-source) + IzzyBoat parity (#120/#181)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-27 11:24 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Plan**: `.agent/work-plans/issue-19/plan.md` at `4cd2020`
+**PR**: https://github.com/rolker/unh_marine_perception/pull/20 (`[PLAN]` prefix)
+**Phases**: single PR, 8 phased atomic commits (+ 1 dependent seafloor config-migration PR)
+
+Plan reconciles the review-issue findings: #10 items D/I/H/E/F/L folded into the rewrite; one
+cohesive perception PR (back-compat single-source) so the code lands before the config flip;
+log-odds chosen as the recommended decay model. fe337f6 (waterline patch) folds into phase 3.
+
+### Open questions
+- [ ] Decay/clearing model — log-odds (recommended) vs hit/miss+time-decay; confirm/veto at review-plan
+- [ ] Sequencing — perception capability PR first (back-compat), then seafloor config-migration PR to activate cross-camera fusion? (recommended yes)
+- [ ] Default tuning — decay half-life, hit/miss increments, lethal threshold (propose defaults, tune on water)

--- a/.agent/work-plans/issue-19/progress.md
+++ b/.agent/work-plans/issue-19/progress.md
@@ -92,3 +92,26 @@ body-pixel NO_INFORMATION safety).
 - [ ] (suggestion) Bounds-guard `is_waterline_contact_pixel` at entry for future callers. — `segments_projection.hpp:64`
 - [ ] (suggestion) Rename/recomment "FractionalShifts" test: grid_map snaps move() to integer cells, so it proves no-drift + exposed-unobserved, not sub-cell residual. — `test_occupancy_buffer.cpp:95`
 - [ ] (suggestion) `setParams`/ctor trust caller to validate; phase-6 param callback is the enforced gate (deferred). — `occupancy_buffer.hpp:99`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-27 14:04 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: changes-requested → addressed
+
+**Branch**: feature/issue-19 at `3f618a1`
+**Mode**: pre-push
+**Depth**: Standard (reason: phase-3 layer rewrite — safety costmap layer, TF + projection + rolling)
+**Must-fix**: 1 | **Suggestions**: 3
+
+Phase 3 (layer consumes occupancy buffer). cppcheck clean (lone hit is a cross-TU false positive).
+Claude + Copilot adversarial both confirmed the risky geometry CORRECT (TF cam→world direction
+matches the reflex feed; project_observations contact/occlusion; rolling-vs-resize split = #10-D fix;
+decay/threshold cycle; LETHAL-only master stamping). Both independently flagged the camera_model_ race
+(cross-model) — fixed in `3f618a1`.
+
+### Findings
+- [x] (must-fix) camera_model_ read/deref outside lock vs locked write → torn read/UAF; fixed via immutable-snapshot (fresh model swap + shared_ptr copy under lock) — `sea_surface_layer.cpp` (3f618a1)
+- [ ] (suggestion, phase 5) `current_` never set true → affects LayeredCostmap::isCurrent(); pre-existing, fold into phase-5 thread-safety/lifecycle — `sea_surface_layer.cpp`
+- [ ] (suggestion) `maximum_range_` (100) advertises reach the buffer window can't fill; observations past the window are projected then dropped — clamp to half-extent or document — `sea_surface_layer.cpp`
+- [ ] (suggestion) remaining camera_model_/count_x_ thread-safety hardening still owed to phase 5 (this fix covers camera_model_; count_x_ read in updateBounds still unlocked) — `sea_surface_layer.cpp`

--- a/.agent/work-plans/issue-19/progress.md
+++ b/.agent/work-plans/issue-19/progress.md
@@ -115,3 +115,65 @@ decay/threshold cycle; LETHAL-only master stamping). Both independently flagged 
 - [ ] (suggestion, phase 5) `current_` never set true → affects LayeredCostmap::isCurrent(); pre-existing, fold into phase-5 thread-safety/lifecycle — `sea_surface_layer.cpp`
 - [ ] (suggestion) `maximum_range_` (100) advertises reach the buffer window can't fill; observations past the window are projected then dropped — clamp to half-extent or document — `sea_surface_layer.cpp`
 - [ ] (suggestion) remaining camera_model_/count_x_ thread-safety hardening still owed to phase 5 (this fix covers camera_model_; count_x_ read in updateBounds still unlocked) — `sea_surface_layer.cpp`
+
+## Offline Review: projection regression + global-costmap design
+**Status**: investigation complete; plan revised
+**When**: 2026-05-27 20:41 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Branch**: feature/issue-19 (local WIP: `bag_to_costmap_video` mosaic + inverse prototype + per-camera counters — not yet committed/reviewed)
+**Artifacts**: `~/data/logs/analysis/2026-05-27/mosaic_ep21_fwd_vs_inv/` — mosaic on the 2026-05-26 bag, episode #21 (13:17:41 EDT, ~2.0 m/s approach → STOP)
+
+Built an offline `bag_to_costmap_video` tool that replays recorded OAK segmentation through the phase-3
+pipeline and renders a 4-panel mosaic (4-cam segmentation | live boat costmap | NEW forward | NEW inverse),
+boat-centred and aligned in `map_tide`. Used it to A/B the projection direction on real water imagery.
+
+### Findings
+- [ ] (must-fix → plan) **Projection regression: forward, not inverse.** The committed phase-3
+  `project_observations` is forward per-pixel (pixel → one world point → one cell), despite the plan's
+  inverse / #10-I loop-inversion intent and the pre-#19 layer's inverse (cell→pixel) loop. Forward →
+  gaps at range, lone jittery hits that never reach the 2-hit lethal threshold, and a far-horizon speckle
+  "ring". Measured ep#21: **0.1 % lethal (forward) vs 3.2 % (inverse)** vs 6.8 % (live chart costmap);
+  inverse fills a coherent footprint that tracks the live obstacle through the maneuver. **Plan phase 3
+  updated to restore inverse projection** (keep contact-only; add an FOV frustum cull for cost).
+- [ ] (architecture → plan) **Buoys never reach the planner.** The controller (`CrabbingPathFollower`)
+  doesn't read the costmap; the global planner (`SmacPlannerHybrid`) plans on the global costmap, which
+  has charts + inflation but no segmentation. So the local sea-surface layer is operator-display-only for
+  planning. **Decision recorded:** publish-and-relay — `SeaSurfaceLayer` publishes its grid_map
+  contribution; a new thin `SeaSurfaceRelayLayer` feeds the global costmap (before inflation), mirroring
+  the `s57_grids`/`s57_layer` producer/consumer pattern. Projection runs once. New cross-repo scope.
+- [x] (no-op) The "blank aft tile" in the first mosaic was a thumbnail misread, **not** a bug:
+  per-camera counters show all four cameras fed the buffer (0 TF failures, ~4.4–4.7 M obs each). Kept the
+  counters + tile-store-before-TF as defensive hardening in the tool.
+
+### Open
+- [x] Global relay scope — **decided: all in #19** (no separate issue, 2026-05-27).
+- [ ] Commit/review the `bag_to_costmap_video` tool (mosaic + inverse prototype) — still local WIP.
+- [ ] seafloor remaining: migrate local 4→1 multi-source (the #19 finalizer) + add the global relay layer.
+
+**Correction (2026-05-27):** seafloor #18 is **closed/done** — it already re-enabled the layer as 4
+direction-named instances live in `bizzyboat_project11/config/nav2_overlay.yaml`, running the **pre-#19
+inverse** code. So segmentation IS deployed (local), and the LIVE panel in the A/B reflects inverse
+segmentation (chart + inverse sea-surface + inflation), not charts alone. This reframes the regression:
+the #19 forward `project_observations` regresses vs the **inverse layer currently running on bizzy**.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-27 23:04 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-19 (pre-push delta only — vs `origin/feature/issue-19`; phases 1+3 already reviewed)
+**Mode**: pre-push
+**Depth**: Standard (reason: ~625 lines, 5 files, governance-touching plan + non-trivial C++ tool)
+**Static**: cppcheck clean; xmllint clean
+**Adversarial**: Claude + Copilot (both, cross-confirmed on findings 2 + 3 + 6)
+**Must-fix**: 1 | **Suggestions**: 5
+
+### Findings
+- [ ] (must-fix) Inverse path marks sky (blue-dominant) as `miss` — overclear in the OURS panel; classify water=miss / sky=skip / contact=hit. — `tools/bag_to_costmap_video.cpp:201`
+- [ ] (suggestion) No arg validation — `--res`/`--window-m`/`--render-dt`/`--max-range` accept ≤0 → divide-by-zero/invalid Mat. — `tools/bag_to_costmap_video.cpp:231`
+- [ ] (suggestion) `render_live` assumes identity grid origin orientation + `bizzy/map_tide` frame — warn if violated. — `tools/bag_to_costmap_video.cpp:129`
+- [ ] (suggestion) No staleness guard on `live_costmap`; once latched, stale grid renders forever. — `tools/bag_to_costmap_video.cpp:303`
+- [ ] (suggestion) `obs_fed` counter semantics changed (inverse cells, not forward pixels); rename or legend. — `tools/bag_to_costmap_video.cpp:393`
+- [ ] (suggestion) Stale prose around the dropped forward A/B — plan + CMakeLists comment. — `plan.md`, `CMakeLists.txt:107`

--- a/.agent/work-plans/issue-19/progress.md
+++ b/.agent/work-plans/issue-19/progress.md
@@ -68,3 +68,27 @@ migration is local_costmap-only (plan scope correct). Four must-fixes below.
 - [ ] (suggestion) Phase-6 param callback: validate (reject NaN/negative/out-of-range, return successful=false), no re-lock — plan.md phase 6
 - [ ] (suggestion) State a per-phase invariant: each commit leaves the layer buildable AND single-source-correct — plan.md Approach
 - [ ] (suggestion) Reconsider `isClearable()` (hard-coded false today) under a decaying-occupancy model — plan.md phase 1/5
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-27 13:12 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-19 at `76c0c38`
+**Mode**: pre-push
+**Depth**: Standard (reason: ~390-line C++ change to a perception costmap-layer package)
+**Must-fix**: 3 | **Suggestions**: 3
+
+Phase 1 (grid_map occupancy buffer). cppcheck clean. Claude + Copilot adversarial both independently
+flagged the lethal_threshold lower-bound gap (cross-model confirmation). Architecture/logic otherwise
+confirmed correct by both (NaN-as-prior, decay vectorization, grid_map move semantics, row/col order,
+body-pixel NO_INFORMATION safety).
+
+### Findings
+- [ ] (must-fix) `validate()` accepts non-positive `lethal_threshold` → 0 makes a single hit lethal (defeats flicker rejection); negative makes a water `miss` read lethal (safety inversion). Require `>0`. — `occupancy_buffer.hpp:114`
+- [ ] (must-fix) `decay()` advances `last_decay_s_` before the `dt<=0` guard + uses `<0` as seed sentinel → backward-time over-decays next call; negative `now_s` re-seeds forever. Use `seeded_` flag, don't advance clock on non-positive dt. — `occupancy_buffer.hpp:69`
+- [ ] (must-fix) Validation test only checks the upper threshold bound; add negative-threshold rejection + backward-time decay cases. — `test_occupancy_buffer.cpp`
+- [ ] (suggestion) Bounds-guard `is_waterline_contact_pixel` at entry for future callers. — `segments_projection.hpp:64`
+- [ ] (suggestion) Rename/recomment "FractionalShifts" test: grid_map snaps move() to integer cells, so it proves no-drift + exposed-unobserved, not sub-cell residual. — `test_occupancy_buffer.cpp:95`
+- [ ] (suggestion) `setParams`/ctor trust caller to validate; phase-6 param callback is the enforced gate (deferred). — `occupancy_buffer.hpp:99`

--- a/.agent/work-plans/issue-19/progress.md
+++ b/.agent/work-plans/issue-19/progress.md
@@ -171,9 +171,41 @@ the #19 forward `project_observations` regresses vs the **inverse layer currentl
 **Must-fix**: 1 | **Suggestions**: 5
 
 ### Findings
-- [ ] (must-fix) Inverse path marks sky (blue-dominant) as `miss` — overclear in the OURS panel; classify water=miss / sky=skip / contact=hit. — `tools/bag_to_costmap_video.cpp:201`
-- [ ] (suggestion) No arg validation — `--res`/`--window-m`/`--render-dt`/`--max-range` accept ≤0 → divide-by-zero/invalid Mat. — `tools/bag_to_costmap_video.cpp:231`
-- [ ] (suggestion) `render_live` assumes identity grid origin orientation + `bizzy/map_tide` frame — warn if violated. — `tools/bag_to_costmap_video.cpp:129`
-- [ ] (suggestion) No staleness guard on `live_costmap`; once latched, stale grid renders forever. — `tools/bag_to_costmap_video.cpp:303`
-- [ ] (suggestion) `obs_fed` counter semantics changed (inverse cells, not forward pixels); rename or legend. — `tools/bag_to_costmap_video.cpp:393`
-- [ ] (suggestion) Stale prose around the dropped forward A/B — plan + CMakeLists comment. — `plan.md`, `CMakeLists.txt:107`
+- [x] (must-fix) Inverse path marks sky (blue-dominant) as `miss` — overclear in the OURS panel; classify water=miss / sky=skip / contact=hit. — `tools/bag_to_costmap_video.cpp:201` (addressed in `13742d5` tool commit)
+- [x] (suggestion) No arg validation — `--res`/`--window-m`/`--render-dt`/`--max-range` accept ≤0 → divide-by-zero/invalid Mat. — `tools/bag_to_costmap_video.cpp:231` (addressed)
+- [ ] (suggestion) `render_live` assumes identity grid origin orientation + `bizzy/map_tide` frame — warn if violated. — `tools/bag_to_costmap_video.cpp:129` (deferred, defensive)
+- [ ] (suggestion) No staleness guard on `live_costmap`; once latched, stale grid renders forever. — `tools/bag_to_costmap_video.cpp:303` (deferred, defensive)
+- [x] (suggestion) `obs_fed` counter semantics changed (inverse cells, not forward pixels); rename or legend. — `tools/bag_to_costmap_video.cpp:393` (renamed to `obs_inv_cells` / `cells_fed_to_buffer`)
+- [x] (suggestion) Stale prose around the dropped forward A/B — plan + CMakeLists comment. — `plan.md`, `CMakeLists.txt:107` (addressed)
+
+## Phase 3 Implemented (Pre-Push Review)
+**Status**: complete (review); changes committed and pushed for overnight Copilot PR review
+**When**: 2026-05-28 00:11 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved-with-suggestions
+
+**Branch**: feature/issue-19 (pre-push delta only — vs `origin/feature/issue-19`)
+**Mode**: pre-push
+**Depth**: Standard (~242 lines, 4 files, touches production layer code)
+**Static**: cppcheck clean (one cross-TU false-positive filtered)
+**Tests**: 54 / 54 passing (incl. 4 new for `project_observations_inverse`)
+**Adversarial**: Claude (full report); Copilot **skipped — timed out at 300s** without producing findings. No cross-model confirmation this round.
+**Must-fix**: 0 | **Suggestions**: 5
+
+### Scope
+- `src/segments_projection.hpp`: new shared helper `project_observations_inverse` (inverse cell→pixel; contact-only; sky-skip; range-gate; behind-camera early-out).
+- `src/sea_surface_layer.cpp`: `segmentsCallback` switched from forward → inverse; iteration centred on camera-origin XY, half-extent = `maximum_range_`. `resolution_` snapshot added under `costmap_mutex_` (closes pre-existing race vs `matchSize()`).
+- `test/test_segments_projection.cpp`: 4 new tests (all-water, all-sky-skipped, contact-vs-body, max-range).
+- `tools/bag_to_costmap_video.cpp`: removed local copy; calls the shared helper. Smoke-render produced identical per-camera cell counts (5,848,135 / 6,404,148 / 5,306,146 / 6,096,452) before vs after the move.
+
+### Findings (Claude Adversarial)
+- [ ] (suggestion, close-to-must-fix) **Test-coverage gap**: all 4 new tests are nadir + `cx=cy=cam_origin` + single-row stacks, so they don't exercise the production call shape (pitched cameras, `pc[2] ≤ 0` behind-camera reject, off-centre iteration, real occlusion). Add a pitched + off-centre integration test. — `test/test_segments_projection.cpp:528-588`
+- [ ] (suggestion) AABB half-extent = `maximum_range_` over-iterates by ~21% (corners exceed Euclidean gate); add a TODO at the call site for the eventual FOV cone cull. — `sea_surface_layer.cpp:222`
+- [ ] (suggestion) Unthrottled WARN on TF / cv_bridge failures — use `RCLCPP_WARN_THROTTLE` and include source frame_id + stamp. — `sea_surface_layer.cpp:236`
+- [ ] (suggestion, nit) `>=` vs `==` in contact classification — `==` matches forward helper's exact semantics. — `segments_projection.hpp:389`
+- [ ] (suggestion) Add `std::isfinite(uv.x/uv.y)` guard before `std::lround` int-narrowing; matches forward helper's defensive style. — `segments_projection.hpp:384`
+
+### Follow-ups (next session)
+- Resolve the 5 suggestions on the PR: highest-value is the test-coverage gap (a pitched + off-centre test that genuinely exercises the body-vs-contact occlusion + the `pc[2] ≤ 0` reject); the others (FOV-cone TODO, throttled WARN, `==` vs `>=` consistency, `isfinite` narrow guard) are small.
+- Triage the Copilot review GitHub posts overnight on PR #20.
+- Sibling diagnostic issue [#21](https://github.com/rolker/unh_marine_perception/issues/21) (camera↔TF motion-consistency tool) remains captured but unimplemented.

--- a/.agent/work-plans/issue-19/progress.md
+++ b/.agent/work-plans/issue-19/progress.md
@@ -239,3 +239,50 @@ Addresses the 4 outstanding Copilot inline review comments on PR #20:
 - Phase 4 (multi-source consolidation), 6 (live-tunable param callback), 8 (docs + dependent seafloor config PR — the #19 finalizer).
 - New scope per offline review: `SeaSurfaceRelayLayer` global-costmap publish-and-relay (buoys don't reach the planner today — Smac sees only chart+inflation).
 - Sibling diagnostic issue [#21](https://github.com/rolker/unh_marine_perception/issues/21) (camera↔TF motion-consistency tool) remains captured but unimplemented.
+
+## Phases 4–6 + global-relay (pre-push)
+**Status**: 6 commits ready (5 phase + 1 fixup); pre-push sub-agent review complete
+**When**: 2026-05-28 12:10 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approve-with-suggestions (2 must-fix + 2 suggestions addressed; 2 minor suggestions deferred)
+
+**Branch**: feature/issue-19 (6 new commits vs `origin/feature/issue-19`)
+**Tests**: 56 / 56 passing
+**Mode**: pre-push
+
+### Scope (in commit order)
+
+- `39f3fbd` — **phase 5 polish** in `sea_surface_layer.cpp`: (a) `count_x_/count_y_/resolution_` read in `updateBounds` now holds `costmap_mutex_`; (b) `current_=true` set after a successful `segmentsCallback` so `LayeredCostmap::isCurrent()` stops reporting the layer stale; (c) TF / `cv_bridge` failure WARN is now `RCLCPP_WARN_THROTTLE` (5 s) and names the source frame + image stamp; (d) `matchSize()` WARNs when `maximum_range_` exceeds the buffer half-extent (no silent clamp; operator decides between raising the costmap size and lowering `maximum_range`); (e) TODO at the `project_observations_inverse` call site for the future FOV-cone cull (square AABB over-iterates by ~21%).
+
+- `a2c34ed` — **phase 6 validating live-tunable params**: `OnSetParametersCallbackHandle` accepts runtime `ros2 param set` for the 5 `OccupancyParams` scalars + `maximum_range`. Topic and source-list params remain configure-time. The callback builds a candidate copy under the lock, applies the proposed updates, validates via `OccupancyBuffer::validate()` + `maximum_range > 0 && finite`, and only on success swaps under the same lock. NaN / out-of-range / safety-inversion is rejected with `successful=false` and a human-readable `reason` — the safety layer's interpretation cannot be silently poisoned. New test `OccupancyBuffer::SetParamsReinterpretsAccumulatedEvidence` proves the contract (a sub-threshold hit at the default `lethal_threshold=1.0` becomes lethal as soon as `setParams` lowers it to `0.3`, no re-observation). Closes #10 K at the buffer + callback layer; rclcpp::Parameter → field dispatch is not unit-tested (would need an rclcpp test fixture).
+
+- `1106659` — **phase 4 multi-source consolidation**: new `observation_sources` (vector<string>) param. Each named source has `<name>.segmentation_topic` and `<name>.camera_info_topic` (mirrors the nav2 ObstacleLayer per-source pattern). All sources feed the shared world-frame `OccupancyBuffer`, so an obstacle in two cameras' overlap accumulates evidence from every camera — the cross-camera fusion the four per-direction layer instances couldn't do. `Source` struct held in `std::vector<std::unique_ptr<Source>>` (unique_ptr so each Source's address stays stable for the lifetime of the layer; the per-subscription lambdas capture `Source *`). Back-compat: when `observation_sources` is empty (default), the layer reads top-level `segmentation_topic` / `camera_info_topic` and synthesizes a single source named `"default"` — pre-#19 configs work unchanged. The cross-source fusion property is a wiring property best verified by ros2 launch fixture; buffer-side accumulation is already covered. Per-source WARN message identifies the source name.
+
+- `d722cf2` — **publish lethal grid**: optional `nav_msgs::msg::OccupancyGrid` publisher on configurable `published_topic` (empty default = disabled). Cells >= `lethal_threshold` publish as `100`; everything else as `-1` ("no opinion") so consumers never inadvertently clear other layers' marks. QoS `transient_local` depth 1. Hand-rolled grid_map → OccupancyGrid conversion (walks OG cells, queries `buffer_->isLethal` by world position) avoids pulling in grid_map_ros as a build dep; O(W×H) per cycle — 40 k Eigen reads on a 200×200 costmap, negligible vs the segmentation projection.
+
+- `5684350` — **new `SeaSurfaceRelayLayer` plugin**: thin counterpart to the publisher above. Subscribes to a `nav_msgs/OccupancyGrid` topic, caches the latest message, expands master bounds to cover the published grid in `updateBounds`, and stamps `LETHAL_OBSTACLE` into the master where the published cell is `>= 100`. Cell-lookup by world position (so producer and consumer can have different costmap pose / resolution / dimensions and the lethal cells still land at the right world location). Frame mismatch drops the message with a throttled WARN — stamping LETHAL at the wrong world position is a safety risk on an obstacle layer. `isClearable()` returns false (producer owns clearing via decay). New source built into the existing `sea_surface_layer` shared library; `costmap_plugins.xml` adds a second `<class>` entry. End-to-end:
+  - `local_costmap.sea_surface_layer` (SeaSurfaceLayer) with `published_topic: /sea_surface/lethal_grid` →
+  - `global_costmap.sea_surface_relay` (SeaSurfaceRelayLayer) with `topic: /sea_surface/lethal_grid` →
+  - SmacPlannerHybrid sees buoys in the global plan.
+
+- `85e3594` — **fixup from pre-push sub-agent review** of `39f3fbd..5684350`. Addresses both must-fix and 2 suggestions:
+  - (must-fix) `onParametersSet` catches `rclcpp::exceptions::InvalidParameterTypeException` and returns `successful=false`. Previously a wrong-type `ros2 param set` would propagate the exception out of the parameter service callback and likely terminate the node.
+  - (must-fix) `Source` is now constructed step-by-step (`auto src = std::make_unique<Source>(); src->field = …;`) instead of via positional brace-init. The aggregate form would silently mis-initialize if Source's member count changes.
+  - (suggestion) `publishLethalGrid` uses the snapshot pattern — copy the grid_map under `costmap_mutex_`, walk the copy off-lock. Avoids serializing every `segmentsCallback` hit against the ~40k-cell scan.
+  - (suggestion) `onParametersSet` explicitly rejects configure-time params (`observation_sources`, top-level + per-source `segmentation_topic`/`camera_info_topic`, `published_topic`) via a suffix-matched helper. Operator gets clear "restart to apply" feedback instead of a silent accept.
+
+### Sub-agent review findings (fresh-context Claude)
+- [x] **must-fix** `onParametersSet`: `as_double()` throws on type mismatch; node-terminating exception. — `sea_surface_layer.cpp:498-516` (addressed `85e3594`)
+- [x] **must-fix** Source aggregate-init is fragile. — `sea_surface_layer.cpp:104, 123` (addressed `85e3594`)
+- [x] (suggestion) `publishLethalGrid` holds lock through ~40k-cell scan. — `sea_surface_layer.cpp:436-467` (addressed `85e3594`)
+- [x] (suggestion) `onParametersSet` doesn't reject configure-time params. — `sea_surface_layer.cpp` (addressed `85e3594`)
+- [ ] (suggestion) Relay frame-mismatch drops: log INFO on first matching-frame message after a drop streak. — `sea_surface_relay_layer.cpp:155-166` (deferred)
+- [ ] (suggestion) Relay updateBounds/updateCosts re-fetch `latest_` independently — document the one-tick inconsistency window. — `sea_surface_relay_layer.cpp:69-148` (deferred)
+- (nit) Non-virtual dtor pattern; leading blank lines; duplicate `find_package(nav_msgs)`. Deferred — Copilot may surface.
+
+### Follow-ups (next session, post-push)
+- **Phase 8 / finalizer**: seafloor config PR in `unh_echoboats_project11` migrating `bizzyboat_project11/config/nav2_overlay.yaml` from 4 direction-named SeaSurfaceLayer instances → 1 multi-source block in `local_costmap` + the new `SeaSurfaceRelayLayer` in `global_costmap`. IzzyBoat parity per `#120/#181`.
+- Package README/params doc in `sea_surface_segmentation` updating for `observation_sources` + `published_topic` + the runtime-tunable params + the new `SeaSurfaceRelayLayer` plugin.
+- Triage Copilot's post-push re-review on PR #20.
+- Integration test (ros2 launch + bag) for the publisher / relay end-to-end and for the cross-source fusion property in phase 4.
+- Sibling diagnostic issue [#21](https://github.com/rolker/unh_marine_perception/issues/21) (camera↔TF motion-consistency tool) remains captured but unimplemented.

--- a/.agent/work-plans/issue-19/progress.md
+++ b/.agent/work-plans/issue-19/progress.md
@@ -199,13 +199,43 @@ the #19 forward `project_observations` regresses vs the **inverse layer currentl
 - `tools/bag_to_costmap_video.cpp`: removed local copy; calls the shared helper. Smoke-render produced identical per-camera cell counts (5,848,135 / 6,404,148 / 5,306,146 / 6,096,452) before vs after the move.
 
 ### Findings (Claude Adversarial)
-- [ ] (suggestion, close-to-must-fix) **Test-coverage gap**: all 4 new tests are nadir + `cx=cy=cam_origin` + single-row stacks, so they don't exercise the production call shape (pitched cameras, `pc[2] ≤ 0` behind-camera reject, off-centre iteration, real occlusion). Add a pitched + off-centre integration test. — `test/test_segments_projection.cpp:528-588`
+- [x] (suggestion, close-to-must-fix) **Test-coverage gap**: all 4 new tests are nadir + `cx=cy=cam_origin` + single-row stacks, so they don't exercise the production call shape (pitched cameras, `pc[2] ≤ 0` behind-camera reject, off-centre iteration, real occlusion). Add a pitched + off-centre integration test. — `test/test_segments_projection.cpp:528-588` (addressed `e263a21`)
 - [ ] (suggestion) AABB half-extent = `maximum_range_` over-iterates by ~21% (corners exceed Euclidean gate); add a TODO at the call site for the eventual FOV cone cull. — `sea_surface_layer.cpp:222`
 - [ ] (suggestion) Unthrottled WARN on TF / cv_bridge failures — use `RCLCPP_WARN_THROTTLE` and include source frame_id + stamp. — `sea_surface_layer.cpp:236`
-- [ ] (suggestion, nit) `>=` vs `==` in contact classification — `==` matches forward helper's exact semantics. — `segments_projection.hpp:389`
-- [ ] (suggestion) Add `std::isfinite(uv.x/uv.y)` guard before `std::lround` int-narrowing; matches forward helper's defensive style. — `segments_projection.hpp:384`
+- [x] (suggestion, nit) `>=` vs `==` in contact classification — `==` matches forward helper's exact semantics. — `segments_projection.hpp:389` (addressed `939fd24`)
+- [x] (suggestion) Add `std::isfinite(uv.x/uv.y)` guard before `std::lround` int-narrowing; matches forward helper's defensive style. — `segments_projection.hpp:384` (addressed `939fd24`)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-28 10:42 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approve
+
+**Branch**: feature/issue-19 (pre-push delta only — 3 commits vs `origin/feature/issue-19`)
+**Mode**: pre-push
+**Depth**: Standard (~82 lines insertions, 3 files, addresses outstanding Copilot inline review comments)
+**Tests**: 55 / 55 passing
+**Adversarial**: Claude sub-agent (fresh-context); Copilot to re-review post-push
+**Must-fix**: 0 | **Suggestions**: 1 (nit) | **Nits**: 0
+
+### Scope
+Addresses the 4 outstanding Copilot inline review comments on PR #20:
+
+- `9ca9407` — `sea_surface_layer.cpp`: add missing `<chrono>`, `<functional>`, `<mutex>`; `test_segments_projection.cpp`: add missing `<utility>` for `std::pair`. Compile-on-libstdc++-by-transitive-include → make explicit.
+- `939fd24` — `segments_projection.hpp::project_observations_inverse`: align contact classification with forward sibling (`v >= contact_row[u]` → `v == contact_row[u]`); add `std::isfinite(uv.x/uv.y)` guard before `std::lround`. Functionally equivalent against `is_waterline_contact_pixel` (the contact is the lowest obstacle pixel with water directly below OR an auto-contact at the image bottom; any obstacle pixel below the recorded contact would extend an unbroken column to the bottom and displace the recorded contact lower — `>` branch unreachable). Defensive consistency, not behavior change.
+- `e263a21` — `test_segments_projection.cpp`: new `PitchedOffCentreRejectsBehindAndOccludesBody` test. Camera at world (5, 3, 1.5) pitched 30° down looking +x, iteration centred at the camera's XY so the back half is behind. Asserts (a) zero behind-camera observations (pc[2]<=0 gate), (b) ≥1 contact-row hit under pitched optics, (c) observations cluster around camera XY (off-centre iteration), (d) every hit lands at x < 7.30 (contact-row reach + margin; body row 6 would land at x ≈ 7.60).
+
+### Findings (sub-agent)
+- Correctness of `==` equivalence claim verified by tracing `is_waterline_contact_pixel` and the contact-finding loop. The `contact_row[u] == -1` (no contact in column) case is also preserved: old form gated explicitly on `>= 0`; new form fails `v == -1` because `v ≥ 0` after the bounds check.
+- `isfinite` guard is genuinely defensive — `pc[2] > 0` plus a well-posed pinhole won't produce non-finite, but `lround` of non-finite is UB; cheap correctness improvement.
+- Pitched test bounds verified independently (contact ray hits at x ≈ 7.09; body row 6 / principal-point ray at x ≈ 7.60; `x < 7.30` exclusion ≈ 0.30 m on body side). Fails cleanly if `==` regresses to `>=` and body pixels start projecting.
+- All four added standard headers are actually used (`std::chrono::seconds`, `std::bind`/`placeholders`, `std::lock_guard<std::mutex>`, `std::pair`).
+
+- [ ] (suggestion, nit) Pitched test uses `EXPECT_LT` inside a per-observation loop; on regression, every offending observation fires its own message. `ASSERT_LT` would fail-fast and quiet the output. Style preference only; not addressed pre-push. — `test/test_segments_projection.cpp:670`
 
 ### Follow-ups (next session)
-- Resolve the 5 suggestions on the PR: highest-value is the test-coverage gap (a pitched + off-centre test that genuinely exercises the body-vs-contact occlusion + the `pc[2] ≤ 0` reject); the others (FOV-cone TODO, throttled WARN, `==` vs `>=` consistency, `isfinite` narrow guard) are small.
-- Triage the Copilot review GitHub posts overnight on PR #20.
+- Triage Copilot's post-push re-review on PR #20.
+- Phase 5 carry-ins: AABB FOV-cone TODO (`sea_surface_layer.cpp:222`), throttled WARN (`sea_surface_layer.cpp:236`), `current_` lifecycle, `maximum_range_` (100 m) vs buffer window mismatch, remaining `count_x_` race.
+- Phase 4 (multi-source consolidation), 6 (live-tunable param callback), 8 (docs + dependent seafloor config PR — the #19 finalizer).
+- New scope per offline review: `SeaSurfaceRelayLayer` global-costmap publish-and-relay (buoys don't reach the planner today — Smac sees only chart+inflation).
 - Sibling diagnostic issue [#21](https://github.com/rolker/unh_marine_perception/issues/21) (camera↔TF motion-consistency tool) remains captured but unimplemented.

--- a/.agent/work-plans/issue-19/progress.md
+++ b/.agent/work-plans/issue-19/progress.md
@@ -45,3 +45,26 @@ log-odds chosen as the recommended decay model. fe337f6 (waterline patch) folds 
 - [ ] Decay/clearing model — log-odds (recommended) vs hit/miss+time-decay; confirm/veto at review-plan
 - [ ] Sequencing — perception capability PR first (back-compat), then seafloor config-migration PR to activate cross-camera fusion? (recommended yes)
 - [ ] Default tuning — decay half-life, hit/miss increments, lethal threshold (propose defaults, tune on water)
+
+## Plan Review
+**Status**: complete
+**When**: 2026-05-27 11:35 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context)) (same agent identity — performed via fresh-context sub-agent for independence)
+
+**Plan**: `.agent/work-plans/issue-19/plan.md` at `4179d4e`
+**PR**: https://github.com/rolker/unh_marine_perception/pull/20
+**Verdict**: changes-requested
+
+Architecture (single fused world-frame log-odds buffer, mark-at-waterline, temporal decay) is sound;
+ADR-0008 mechanism choices correct. Sub-agent verified global_costmap does NOT use the layer, so the
+migration is local_costmap-only (plan scope correct). Four must-fixes below.
+
+### Findings
+- [ ] (must-fix) Float log-odds buffer can't reuse nav2 `updateOrigin()` (built for uint8 cost cells); phase 1 must spec the float-array shift + prior-fill on exposed cells + a fractional-shift drift test — the load-bearing prerequisite — plan.md phase 1
+- [ ] (must-fix) `Closes #19` pairs with a single-source PR, but #19's signature handoff AC needs the multi-source shared buffer (activated only by the later seafloor config PR) → AC unverifiable in this PR; don't auto-close #19 or carry the handoff AC into the config PR — **surface to user** — plan.md Estimated Scope / Open Questions
+- [ ] (must-fix) "fixes #10 H" overstated: waterline-contact addresses shadow-smear, NOT the `map_tide` z=0 vertical-drift (orthogonal; contact still back-projects to fixed plane_z=0). Downgrade to "partially addresses H"; parameterize plane_z from tide frame or defer — plan.md phase 3
+- [ ] (must-fix) `project_obstacle_pixels` doesn't drop in (emits points for ALL obstacle pixels; no contact/water-miss/occlusion). Phase 3 needs a new helper (contact-only + free-space/miss raytrace camera→contact) and must confirm `segments_to_pointcloud.cpp` (other consumer) is unaffected — plan.md phase 3
+- [ ] (suggestion) 128×96 mask quantization → contact-range uncertainty is range-dependent; decay/threshold defaults must tolerate a contact jittering across cells at long range (else re-creates flicker) — plan.md phase 3/tuning
+- [ ] (suggestion) Phase-6 param callback: validate (reject NaN/negative/out-of-range, return successful=false), no re-lock — plan.md phase 6
+- [ ] (suggestion) State a per-phase invariant: each commit leaves the layer buildable AND single-source-correct — plan.md Approach
+- [ ] (suggestion) Reconsider `isClearable()` (hard-coded false today) under a decaying-occupancy model — plan.md phase 1/5

--- a/.agent/work-plans/issue-19/progress.md
+++ b/.agent/work-plans/issue-19/progress.md
@@ -286,3 +286,28 @@ Addresses the 4 outstanding Copilot inline review comments on PR #20:
 - Triage Copilot's post-push re-review on PR #20.
 - Integration test (ros2 launch + bag) for the publisher / relay end-to-end and for the cross-source fusion property in phase 4.
 - Sibling diagnostic issue [#21](https://github.com/rolker/unh_marine_perception/issues/21) (camera↔TF motion-consistency tool) remains captured but unimplemented.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-28 11:06 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #20 at `d40e72b`
+**Sources**: 5 (Copilot R1 @ `0c365cc`, Copilot R2 @ `85c3c12`, Copilot R3 @ `3b52d70`, Copilot R4 @ `d40e72b`, Local Review (Pre-Push) entries)
+**Cross-source confirmations**: 4
+**CI**: copilot-pull-request-reviewer = success; no other checks configured. R4 at current HEAD found no new comments.
+
+### Findings
+- [x] (cross-confirmed, Copilot R1 + Local Review) Missing `<mutex>`/`<functional>`/`<chrono>` includes — relies on transitive includes — `sea_surface_segmentation/src/sea_surface_layer.cpp:23` (addressed `9ca9407`)
+- [x] (cross-confirmed, Copilot R1 + Local Review) Missing `<utility>` for `std::pair` — `sea_surface_segmentation/test/test_segments_projection.cpp:480` (addressed `9ca9407`)
+- [x] (cross-confirmed, Copilot R2 + Local Review) Inverse projection test coverage gap — only nadir, only centred iteration, only single-row stacks — `sea_surface_segmentation/test/test_segments_projection.cpp:589` (addressed `e263a21`: `PitchedOffCentreRejectsBehindAndOccludesBody`)
+- [x] (cross-confirmed, Copilot R2 + Local Review) `v >= contact_row[u]` vs forward sibling's `==` — semantic divergence — `sea_surface_segmentation/src/segments_projection.hpp:389` (addressed `939fd24`: align to `==` + isfinite guard)
+- [ ] (must-fix, Copilot R3) **Critical runtime bug**: `add_on_set_parameters_callback` registered at line 184; `declare_parameter("published_topic", ...)` at line 193 then triggers the callback for the initial-value validation; the callback's `is_configure_time` helper rejects `.published_topic` with `successful=false`; rclcpp turns that into `InvalidParameterValueException`, aborting `onInitialize` — the layer fails to load every time. Not caught by 57/57 GTests (none instantiate the layer via pluginlib). Fix: move `published_topic` declaration before the callback registration, or (cleaner) move the callback registration to the end of `onInitialize` after every `declareParameter`. — `sea_surface_segmentation/src/sea_surface_layer.cpp:184,193`
+- [ ] (must-fix, Copilot R3) Race on `maximum_range_`: `updateBounds` reads it 4× outside `costmap_mutex_`, but `onParametersSet` writes it under the lock. Copilot flagged the *segmentsCallback* site (now `d40e72b` reads it under the lock alongside `min_grazing_angle_deg_`), but the same race remains in `updateBounds`. Fix: snapshot under the lock at the top of `updateBounds`, use local copy for the bound-expansion reads. — `sea_surface_segmentation/src/sea_surface_layer.cpp:220-223`
+
+### False positives
+- None this round — Copilot's findings are all valid or already-addressed.
+
+### Follow-ups
+- After the two must-fix patches, push and wait for Copilot R5; expected clean.
+- Consider adding a pluginlib-loading smoke test in `BUILD_TESTING` to catch declaration-order bugs like #6 (currently no test instantiates the layer through `nav2_costmap_2d::LayeredCostmap::registerInitialPlugins`). Tracked here as a deferred follow-up; not blocking the PR.

--- a/.agent/work-plans/issue-19/progress.md
+++ b/.agent/work-plans/issue-19/progress.md
@@ -1,0 +1,29 @@
+---
+issue: 19
+---
+
+# Issue #19 — Re-architect SeaSurfaceLayer as a single multi-camera fused occupancy layer (temporal persistence + decay)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-05-27 10:37 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Issue**: #19
+**Comment**: https://github.com/rolker/unh_marine_perception/issues/19#issuecomment-4555511506
+**Scope verdict**: needs-splitting
+
+Issue is well-written as a design/tracking spec (evidence-backed motivation, nav2-idiomatic design,
+acceptance criteria, surfaced decay-model decision) and is in the right repo. The implementation is
+too large for one PR and overlaps the #10 umbrella (D, I, H, L, E/F) — both need handling before/at
+plan-task. ROS 2 convention alignment (ADR-0008) is positive: adopts nav2 ObstacleLayer multi-source
+idiom.
+
+### Actions
+- [ ] Cross-link #10 in the issue and declare which items #19 closes (D matchSize-nuke, I loop-inversion; address H map_tide z=0; satisfies L tests; folds E/F threading into shared-buffer design)
+- [ ] plan-task: decompose into sequenced/stacked PRs — (a) decouple internal grid from rolling origin (#10 D, prerequisite for any persistence), (b) consolidate 4 instances → 1 multi-source single-buffer (behavior-preserving), (c) add persistence + decay, (d) loop-inversion (#10 I, likely folded into a)
+- [ ] Make shared-buffer thread-safety an explicit design requirement (N camera + camera_info callbacks → one buffer); resolves #10 E/F
+- [ ] Address #10 H (map_tide z=0 / vertical-drift assumption) in the world-frame buffer design
+- [ ] Settle the decay-model open question (log-odds vs hit/miss+time-decay) before plan-task locks the design; record the choice in the issue
+- [ ] Tests targeting persistence/decay, multi-camera fusion, and concurrency (satisfies #10 L)
+- [ ] Track cross-repo config consequence: seafloor_echoboat_project11 nav2_params.yaml (4 blocks → 1 multi-source) + IzzyBoat parity (#120/#181)

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(grid_map_core REQUIRED)
 get_target_property(grid_map_core_INC grid_map_core::grid_map_core INTERFACE_INCLUDE_DIRECTORIES)
 include_directories(${grid_map_core_INC})
 find_package(lifecycle_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(pcl_ros REQUIRED)
@@ -81,6 +82,7 @@ install(TARGETS segments_to_pointcloud
 
 add_library("sea_surface_layer" SHARED
   src/sea_surface_layer.cpp
+  src/sea_surface_relay_layer.cpp
 )
 add_library("sea_surface_layer::sea_surface_layer" ALIAS "sea_surface_layer")
 
@@ -90,6 +92,7 @@ target_link_libraries(sea_surface_layer
   nav2_costmap_2d::nav2_costmap_2d_core
   rclcpp::rclcpp
   tf2_ros::tf2_ros
+  ${nav_msgs_TARGETS}
 )
 
 ament_target_dependencies(sea_surface_layer

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -104,6 +104,32 @@ install(
   DESTINATION lib
 )
 
+# Offline bag → costmap video tool (#19 verification): replays recorded
+# segmentation through the OccupancyBuffer with the corrected INVERSE (cell→pixel)
+# projection, rendering a mosaic (4-cam tiles | live boat costmap | OURS-inverse)
+# for review before deployment. The forward `project_observations` lives in
+# segments_projection.hpp for the reflex pointcloud feed but is not used here.
+find_package(rosbag2_cpp REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(OpenCV REQUIRED)
+add_executable(bag_to_costmap_video tools/bag_to_costmap_video.cpp)
+target_include_directories(bag_to_costmap_video PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(bag_to_costmap_video
+  grid_map_core::grid_map_core
+  image_geometry::image_geometry
+  rclcpp::rclcpp
+  rosbag2_cpp::rosbag2_cpp
+  tf2::tf2
+  ${OpenCV_LIBS}
+  ${sensor_msgs_TARGETS}
+  ${tf2_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+)
+ament_target_dependencies(bag_to_costmap_video cv_bridge)
+install(TARGETS bag_to_costmap_video DESTINATION lib/${PROJECT_NAME})
+
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -17,6 +17,14 @@ find_package(depthai CONFIG REQUIRED)
 find_package(depthai_bridge REQUIRED)
 find_package(depthai_marine REQUIRED)
 find_package(image_geometry REQUIRED)
+find_package(grid_map_core REQUIRED)
+# grid_map_core's extras inject -DEIGEN_*_PLUGIN globally via add_definitions, so
+# every TU compiled past this point needs grid_map_core's include dir to find the
+# plugin headers — not just the targets that link grid_map_core::grid_map_core.
+# The legacy *_INCLUDE_DIRS var is empty under the modern target export, so pull
+# the path from the imported target and add it globally.
+get_target_property(grid_map_core_INC grid_map_core::grid_map_core INTERFACE_INCLUDE_DIRECTORIES)
+include_directories(${grid_map_core_INC})
 find_package(lifecycle_msgs REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
 find_package(pcl_conversions REQUIRED)
@@ -144,6 +152,17 @@ if(BUILD_TESTING)
     image_geometry::image_geometry
     tf2::tf2
     ${sensor_msgs_TARGETS}
+  )
+
+  # occupancy_buffer.hpp is the pure log-odds buffer (grid_map storage +
+  # rolling); private to the layer in src/, exercised via this GTest. Links
+  # grid_map_core for GridMap.
+  ament_add_gtest(test_occupancy_buffer test/test_occupancy_buffer.cpp)
+  target_include_directories(test_occupancy_buffer PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+  target_link_libraries(test_occupancy_buffer
+    grid_map_core::grid_map_core
   )
 
   # launch_testing integration: replay a 20s slice of the 2026-05-22

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -195,6 +195,27 @@ if(BUILD_TESTING)
     grid_map_core::grid_map_core
   )
 
+  # Plugin smoke test: loads each costmap_2d plugin via pluginlib AND calls
+  # `Layer::initialize` against a real LayeredCostmap + LifecycleNode. The
+  # initialize path is what surfaces declaration-order bugs in `onInitialize`
+  # (e.g. registering an on-set-parameters callback before declaring a param
+  # the callback would reject — throws InvalidParameterValueException during
+  # `declare_parameter`'s initial-value validation, abort onInitialize, layer
+  # fails to load at deployment). Unit tests that exercise the pure helpers
+  # don't reach this path; this test does. Links nav2_costmap_2d_core +
+  # nav2_util for LayeredCostmap + LifecycleNode and pluginlib for ClassLoader.
+  find_package(nav2_util REQUIRED)
+  ament_add_gtest(test_layer_plugin_loading test/test_layer_plugin_loading.cpp)
+  target_link_libraries(test_layer_plugin_loading
+    nav2_costmap_2d::nav2_costmap_2d_core
+    tf2_ros::tf2_ros
+  )
+  ament_target_dependencies(test_layer_plugin_loading
+    nav2_util
+    pluginlib
+    rclcpp
+  )
+
   # launch_testing integration: replay a 20s slice of the 2026-05-22
   # deployment bag through segments_to_pointcloud in reflex-mode and
   # assert obstacle points land in the forward danger sector. This

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -84,7 +84,8 @@ add_library("sea_surface_layer" SHARED
 )
 add_library("sea_surface_layer::sea_surface_layer" ALIAS "sea_surface_layer")
 
-target_link_libraries(sea_surface_layer 
+target_link_libraries(sea_surface_layer
+  grid_map_core::grid_map_core
   image_geometry::image_geometry
   nav2_costmap_2d::nav2_costmap_2d_core
   rclcpp::rclcpp

--- a/sea_surface_segmentation/config/README.md
+++ b/sea_surface_segmentation/config/README.md
@@ -85,3 +85,134 @@ IncludeLaunchDescription(
     }.items(),
 )
 ```
+
+## `sea_surface_layer::SeaSurfaceLayer` (costmap_2d plugin)
+
+A `nav2_costmap_2d::Layer` plugin that fuses one or more camera
+segmentation streams into a single persistent, decaying log-odds
+occupancy buffer in the costmap's global frame, and stamps cells whose
+accumulated evidence has crossed the lethal threshold into the master
+costmap. Replaces the pre-#19 per-camera layer instances (each with a
+private buffer wiped every frame), giving cross-camera fusion and
+short-term obstacle memory through FOV handoffs.
+
+### Sources
+
+The layer accepts one OR more camera sources. Multi-source is
+configured via `observation_sources` (a list of source names); each
+named source declares its own segmentation + camera_info topics:
+
+```yaml
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      plugins: ["chart_layer", "sea_surface_layer", "inflation_layer"]
+      sea_surface_layer:
+        plugin: "sea_surface_layer::SeaSurfaceLayer"
+        observation_sources: ["forward", "port", "starboard", "aft"]
+        forward:
+          segmentation_topic: bizzy/sensors/cameras/oak_forward/segmentation
+          camera_info_topic:  bizzy/sensors/cameras/oak_forward/segmentation/camera_info
+        port:
+          segmentation_topic: bizzy/sensors/cameras/oak_port/segmentation
+          camera_info_topic:  bizzy/sensors/cameras/oak_port/segmentation/camera_info
+        # ... starboard, aft analogously
+        maximum_range: 150.0
+        published_topic: /sea_surface/lethal_grid  # for SeaSurfaceRelayLayer
+```
+
+When `observation_sources` is empty (default), the layer falls back to
+top-level `segmentation_topic` / `camera_info_topic` as a single source
+named `"default"` — pre-#19 single-camera configs work unchanged.
+
+All sources feed the same shared occupancy buffer in the costmap's
+global frame, so an obstacle in two cameras' FOV overlap accumulates
+evidence from every camera that sees it (faster threshold crossing,
+fewer flicker losses) and persists across FOV handoffs.
+
+### Parameters
+
+| Parameter | Type | Default | Live-tunable | Purpose |
+|---|---|---|---|---|
+| `observation_sources` | string[] | `[]` | no | Named sources. Empty falls back to single-source legacy mode. |
+| `<source>.segmentation_topic` | string | `""` | no | Per-source obstacle-mask topic. |
+| `<source>.camera_info_topic` | string | `""` | no | Per-source intrinsics topic. |
+| `segmentation_topic` | string | `"segmentation"` | no | Legacy single-source (when `observation_sources` is empty). |
+| `camera_info_topic` | string | `"camera_info"` | no | Legacy single-source. |
+| `maximum_range` | double | `100.0` | **yes** | Projection AABB half-extent per camera (m). |
+| `published_topic` | string | `""` | no | When non-empty, republishes the lethal mask on this topic for `SeaSurfaceRelayLayer`. Empty = disabled. |
+| `hit_log_odds` | double | `0.85` | **yes** | Log-odds added on a waterline-contact observation. |
+| `miss_log_odds` | double | `-0.40` | **yes** | Log-odds added on a water (free-space) observation; negative. |
+| `clamp` | double | `5.0` | **yes** | Symmetric log-odds bound — keeps evidence revisable, prevents saturation. |
+| `lethal_threshold` | double | `1.0` | **yes** | Log-odds at or above which a cell stamps `LETHAL_OBSTACLE`. Must be in `(0, clamp]`. |
+| `decay_half_life_s` | double | `30.0` | **yes** | Unobserved evidence halves every this many wall-clock seconds. |
+
+**Live-tunable**: change via `ros2 param set <costmap_node>
+<layer_name>.<param> <value>`. The validating
+`OnSetParametersCallbackHandle` rejects NaN / out-of-range /
+safety-inverting values (e.g. `lethal_threshold <= 0`, negative
+`maximum_range`) with `successful=false` and a human-readable reason —
+the safety layer's interpretation cannot be silently poisoned by a
+fat-fingered set. Configure-time params (topics, `observation_sources`,
+`published_topic`) are rejected explicitly with a "restart the costmap
+to apply" message so the operator isn't silently misled.
+
+### Behavior notes
+
+- The layer projects pixel→world via the cell→pixel inverse direction
+  (`project_observations_inverse` in `segments_projection.hpp`): iterate
+  the world cells the camera can reach, classify each by the pixel it
+  covers. Waterline contact → hit (evidence ↑); water → miss
+  (evidence ↓); occluded body / sky pixels → skipped (no update). Only
+  the waterline contact gets back-projected onto the water plane (z=0);
+  above-water body pixels would project past the real obstacle as a
+  false "shadow" of lethal cells out to maximum_range.
+- The buffer rolls with the parent costmap via `grid_map::move()` — a
+  pure circular-buffer index shift that preserves accumulated evidence
+  at its world position through sub-cell origin shifts (no drift to
+  neighboring cells).
+- `isClearable()` is false: the layer clears itself via water-miss
+  observations + time-based decay, so nav2 clear-costmap behaviors
+  don't need to (and shouldn't) wipe it.
+
+## `sea_surface_layer::SeaSurfaceRelayLayer` (costmap_2d plugin)
+
+A thin counterpart to `SeaSurfaceLayer` for the case where the same
+lethal cells should reach a second costmap (typically the global
+costmap, so `SmacPlannerHybrid` plans around buoys). The relay
+subscribes to a `nav_msgs::msg::OccupancyGrid` published by a peer
+`SeaSurfaceLayer` (running in another costmap, with `published_topic`
+set), and stamps `LETHAL_OBSTACLE` into its own master grid where the
+published cell is at or above `100`. The segmentation projection runs
+only once — in the producer.
+
+### Configuration
+
+```yaml
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      plugins: ["chart_layer", "sea_surface_relay", "inflation_layer"]
+      sea_surface_relay:
+        plugin: "sea_surface_layer::SeaSurfaceRelayLayer"
+        topic: /sea_surface/lethal_grid
+```
+
+| Parameter | Type | Default | Purpose |
+|---|---|---|---|
+| `topic` | string | `"sea_surface/lethal_grid"` | OccupancyGrid topic published by the peer `SeaSurfaceLayer`. |
+
+### Behavior notes
+
+- Only cells published as `100` (lethal) stamp into the master; `-1`
+  ("no opinion") cells leave the master untouched, so the relay never
+  inadvertently clears another layer's marks (the global costmap's
+  chart + inflation contributions stay authoritative; sea-surface only
+  ADDS).
+- Cell-lookup is by world position, so the producer's costmap and the
+  consumer's can have different pose / resolution / dimensions and the
+  lethal cells still land at the correct world location.
+- The relay drops messages whose `header.frame_id` doesn't match the
+  consumer's `getGlobalFrameID()` — stamping LETHAL at the wrong world
+  position is a safety risk on an obstacle layer.
+- `isClearable()` is false (the producer owns clearing via decay).

--- a/sea_surface_segmentation/config/README.md
+++ b/sea_surface_segmentation/config/README.md
@@ -140,6 +140,7 @@ fewer flicker losses) and persists across FOV handoffs.
 | `segmentation_topic` | string | `"segmentation"` | no | Legacy single-source (when `observation_sources` is empty). |
 | `camera_info_topic` | string | `"camera_info"` | no | Legacy single-source. |
 | `maximum_range` | double | `100.0` | **yes** | Projection AABB half-extent per camera (m). |
+| `min_grazing_angle_deg` | double | `0.0` | **yes** | Reject rays that hit the water plane at less than this angle from horizontal. `0` = filter off. Bounds horizontal reach to ≈ `camera_height / tan(angle)`; cuts long-range noise where small pitch uncertainty produces large ground error. |
 | `published_topic` | string | `""` | no | When non-empty, republishes the lethal mask on this topic for `SeaSurfaceRelayLayer`. Empty = disabled. |
 | `hit_log_odds` | double | `0.85` | **yes** | Log-odds added on a waterline-contact observation. |
 | `miss_log_odds` | double | `-0.40` | **yes** | Log-odds added on a water (free-space) observation; negative. |

--- a/sea_surface_segmentation/costmap_plugins.xml
+++ b/sea_surface_segmentation/costmap_plugins.xml
@@ -2,4 +2,7 @@
   <class type="sea_surface_layer::SeaSurfaceLayer" base_class_type="nav2_costmap_2d::Layer">
     <description>A sea surface segmentation layer for costmap_2d</description>
   </class>
+  <class type="sea_surface_layer::SeaSurfaceRelayLayer" base_class_type="nav2_costmap_2d::Layer">
+    <description>Relay layer that stamps lethal cells published by a peer SeaSurfaceLayer (typically in local_costmap) into a different costmap (typically global_costmap), so the segmentation projection runs only once but reaches both planners.</description>
+  </class>
 </library>

--- a/sea_surface_segmentation/package.xml
+++ b/sea_surface_segmentation/package.xml
@@ -16,6 +16,7 @@
   <depend>depthai</depend>
   <depend>depthai_bridge</depend>
   <depend>depthai_marine</depend>
+  <depend>grid_map_core</depend>
   <depend>image_geometry</depend>
   <depend>lifecycle_msgs</depend>
   <depend>nav2_costmap_2d</depend>

--- a/sea_surface_segmentation/package.xml
+++ b/sea_surface_segmentation/package.xml
@@ -20,12 +20,16 @@
   <depend>image_geometry</depend>
   <depend>lifecycle_msgs</depend>
   <depend>nav2_costmap_2d</depend>
+  <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>rosbag2_cpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/sea_surface_segmentation/src/occupancy_buffer.hpp
+++ b/sea_surface_segmentation/src/occupancy_buffer.hpp
@@ -63,10 +63,14 @@ public:
   // the clock. NaN (unobserved) cells are unaffected (NaN * factor == NaN).
   void decay(double now_s)
   {
-    if (last_decay_s_ < 0.0) { last_decay_s_ = now_s; return; }
+    if (!seeded_) { seeded_ = true; last_decay_s_ = now_s; return; }
     const double dt = now_s - last_decay_s_;
-    last_decay_s_ = now_s;
+    // On a non-positive dt (backward time jump / clock reset) do nothing AND
+    // don't advance the reference, so the next forward step measures true
+    // elapsed time and a time discontinuity never erases evidence (the safe
+    // direction for an obstacle layer).
     if (dt <= 0.0 || params_.decay_half_life_s <= 0.0) { return; }
+    last_decay_s_ = now_s;
     const float factor = static_cast<float>(std::pow(0.5, dt / params_.decay_half_life_s));
     grid_map::Matrix & data = map_["log_odds"];
     data = (data.array() * factor).matrix();
@@ -111,8 +115,13 @@ public:
     if (!std::isfinite(p.clamp) || p.clamp <= 0.0) {
       why = "clamp must be finite and > 0"; return false;
     }
-    if (!std::isfinite(p.lethal_threshold) || p.lethal_threshold > p.clamp) {
-      why = "lethal_threshold must be finite and <= clamp"; return false;
+    if (!std::isfinite(p.lethal_threshold) || p.lethal_threshold <= 0.0 ||
+      p.lethal_threshold > p.clamp)
+    {
+      // Lower bound matters: a threshold of 0 makes a single hit lethal (defeats
+      // flicker rejection); a negative one makes a water `miss` read lethal — a
+      // safety inversion on an obstacle layer.
+      why = "lethal_threshold must be finite and in (0, clamp]"; return false;
     }
     if (!std::isfinite(p.decay_half_life_s) || p.decay_half_life_s <= 0.0) {
       why = "decay_half_life_s must be finite and > 0"; return false;
@@ -132,7 +141,8 @@ private:
 
   grid_map::GridMap map_;
   OccupancyParams params_;
-  double last_decay_s_ = -1.0;
+  double last_decay_s_ = 0.0;
+  bool seeded_ = false;
 };
 
 }  // namespace sea_surface_segmentation

--- a/sea_surface_segmentation/src/occupancy_buffer.hpp
+++ b/sea_surface_segmentation/src/occupancy_buffer.hpp
@@ -92,6 +92,14 @@ public:
     return static_cast<double>(map_.atPosition("log_odds", position));
   }
 
+  // Forget everything — reset all cells to unobserved and re-seed the decay
+  // clock on the next decay() call.
+  void clear()
+  {
+    map_["log_odds"].setConstant(NAN);
+    seeded_ = false;
+  }
+
   const grid_map::GridMap & map() const { return map_; }
   const OccupancyParams & params() const { return params_; }
 

--- a/sea_surface_segmentation/src/occupancy_buffer.hpp
+++ b/sea_surface_segmentation/src/occupancy_buffer.hpp
@@ -1,0 +1,140 @@
+#ifndef SEA_SURFACE_SEGMENTATION__OCCUPANCY_BUFFER_HPP_
+#define SEA_SURFACE_SEGMENTATION__OCCUPANCY_BUFFER_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include <grid_map_core/grid_map_core.hpp>
+
+namespace sea_surface_segmentation
+{
+
+// Tunable parameters for the log-odds occupancy buffer. All are runtime-
+// reconfigurable on the live layer (validated via `validate()` before apply).
+struct OccupancyParams
+{
+  double hit_log_odds = 0.85;       // added to a cell on an obstacle observation
+  double miss_log_odds = -0.40;     // added on a free-space (water) observation; negative
+  double clamp = 5.0;               // |log-odds| bound, so evidence stays revisable (no saturation)
+  double lethal_threshold = 1.0;    // log-odds >= this => the cell reads as a lethal obstacle
+  double decay_half_life_s = 30.0;  // unobserved evidence halves every this many seconds
+};
+
+// A rolling, world-frame occupancy grid that accumulates obstacle evidence as
+// per-cell log-odds and forgets it over time (decay toward the prior).
+//
+// Design notes:
+//   - Storage and rolling are delegated to `grid_map::GridMap`: `move()` shifts
+//     the window by circular-buffer index (no per-cell copy), preserves the
+//     overlapping data at its world position, and fills newly-exposed cells with
+//     NaN. We treat NaN as "unobserved" (the prior) — a cell only becomes lethal
+//     after enough obstacle observations accumulate, so single-frame flicker is
+//     rejected, and evidence persists through gaps until it decays away.
+//   - Pure logic, no ROS/nav2 types, so it is unit-testable in isolation. The
+//     costmap layer owns the grid_map<->Costmap2D bridge and the camera geometry.
+class OccupancyBuffer
+{
+public:
+  OccupancyBuffer(
+    double size_x_m, double size_y_m, double resolution,
+    const grid_map::Position & center, const OccupancyParams & params)
+  : map_(std::vector<std::string>{"log_odds"}), params_(params)
+  {
+    map_.setGeometry(grid_map::Length(size_x_m, size_y_m), resolution, center);
+    map_["log_odds"].setConstant(NAN);  // start fully unobserved
+  }
+
+  // Roll the window so it re-centers on `position`. Overlapping cells keep their
+  // accumulated evidence at the same world location; newly-exposed cells are NaN
+  // (unobserved). Sub-cell motion is absorbed by grid_map's internal offset, so a
+  // sequence of fractional-meter shifts does not drift evidence to a wrong cell.
+  bool move(const grid_map::Position & position) { return map_.move(position); }
+
+  // Accumulate an obstacle observation at `position` (clamped log-odds).
+  bool hit(const grid_map::Position & position) { return apply(position, params_.hit_log_odds); }
+
+  // Accumulate a free-space (water) observation at `position` (clamped log-odds).
+  bool miss(const grid_map::Position & position) { return apply(position, params_.miss_log_odds); }
+
+  // Decay all observed cells toward the prior based on wall-clock elapsed time.
+  // Call once per update cycle with the current time; the first call only seeds
+  // the clock. NaN (unobserved) cells are unaffected (NaN * factor == NaN).
+  void decay(double now_s)
+  {
+    if (last_decay_s_ < 0.0) { last_decay_s_ = now_s; return; }
+    const double dt = now_s - last_decay_s_;
+    last_decay_s_ = now_s;
+    if (dt <= 0.0 || params_.decay_half_life_s <= 0.0) { return; }
+    const float factor = static_cast<float>(std::pow(0.5, dt / params_.decay_half_life_s));
+    grid_map::Matrix & data = map_["log_odds"];
+    data = (data.array() * factor).matrix();
+  }
+
+  // True iff `position` is inside the window and its accumulated log-odds has
+  // reached the lethal threshold. Unobserved (NaN) cells read as not-lethal.
+  bool isLethal(const grid_map::Position & position) const
+  {
+    if (!map_.isInside(position)) { return false; }
+    const float v = map_.atPosition("log_odds", position);
+    return std::isfinite(v) && static_cast<double>(v) >= params_.lethal_threshold;
+  }
+
+  // Raw log-odds at `position`; NaN if unobserved or outside the window.
+  double logOdds(const grid_map::Position & position) const
+  {
+    if (!map_.isInside(position)) { return NAN; }
+    return static_cast<double>(map_.atPosition("log_odds", position));
+  }
+
+  const grid_map::GridMap & map() const { return map_; }
+  const OccupancyParams & params() const { return params_; }
+
+  // Replace the tunable parameters (e.g. from a runtime param callback). Existing
+  // accumulated evidence is preserved; a new threshold reinterprets it on the next
+  // read, new increments/decay take effect on the next update. Caller must
+  // `validate()` first.
+  void setParams(const OccupancyParams & params) { params_ = params; }
+
+  // Reject values that would corrupt the buffer's interpretation (so a stray
+  // runtime `ros2 param set` can't silently poison a safety layer). On failure
+  // returns false and sets `why`.
+  static bool validate(const OccupancyParams & p, std::string & why)
+  {
+    if (!std::isfinite(p.hit_log_odds) || p.hit_log_odds <= 0.0) {
+      why = "hit_log_odds must be finite and > 0"; return false;
+    }
+    if (!std::isfinite(p.miss_log_odds) || p.miss_log_odds >= 0.0) {
+      why = "miss_log_odds must be finite and < 0"; return false;
+    }
+    if (!std::isfinite(p.clamp) || p.clamp <= 0.0) {
+      why = "clamp must be finite and > 0"; return false;
+    }
+    if (!std::isfinite(p.lethal_threshold) || p.lethal_threshold > p.clamp) {
+      why = "lethal_threshold must be finite and <= clamp"; return false;
+    }
+    if (!std::isfinite(p.decay_half_life_s) || p.decay_half_life_s <= 0.0) {
+      why = "decay_half_life_s must be finite and > 0"; return false;
+    }
+    return true;
+  }
+
+private:
+  bool apply(const grid_map::Position & position, double increment)
+  {
+    if (!map_.isInside(position)) { return false; }
+    float & v = map_.atPosition("log_odds", position);
+    const double current = std::isfinite(v) ? static_cast<double>(v) : 0.0;  // NaN => prior
+    v = static_cast<float>(std::clamp(current + increment, -params_.clamp, params_.clamp));
+    return true;
+  }
+
+  grid_map::GridMap map_;
+  OccupancyParams params_;
+  double last_decay_s_ = -1.0;
+};
+
+}  // namespace sea_surface_segmentation
+
+#endif  // SEA_SURFACE_SEGMENTATION__OCCUPANCY_BUFFER_HPP_

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -11,6 +11,7 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "segments_apply.hpp"
+#include "segments_projection.hpp"
 
 namespace sea_surface_layer
 {
@@ -196,9 +197,19 @@ private:
               auto pixel_value = image->image.at<cv::Vec3b>(pixel);
               // Segmentation channel convention: dominant R marks non-water
               // (lethal obstacle); dominant G/B marks water (free space).
-              if(pixel_value[0] > pixel_value[1] && pixel_value[0] > pixel_value[2])
+              if(sea_surface_segmentation::is_obstacle_pixel(pixel_value))
               {
-                segments_costmap_.setCost(i, j, nav2_costmap_2d::LETHAL_OBSTACLE);
+                // Only the waterline contact is a trustworthy z=0 footprint. An
+                // obstacle's above-water body pixels back-project far beyond the
+                // real obstacle, smearing a false radial "shadow" of lethal
+                // cells out toward maximum_range. Mark only the contact lethal;
+                // leave the rest at NO_INFORMATION (occluded/unknown — the value
+                // reset at the start of this callback).
+                if(sea_surface_segmentation::is_waterline_contact_pixel(
+                     image->image, static_cast<int>(pixel.y), static_cast<int>(pixel.x)))
+                {
+                  segments_costmap_.setCost(i, j, nav2_costmap_2d::LETHAL_OBSTACLE);
+                }
               }
               else
               {

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -104,10 +104,17 @@ public:
     *max_y = std::max(*max_y, robot_y + maximum_range_);
 
     auto parent = layered_costmap_->getCostmap();
-    const bool geometry_changed =
-      parent->getSizeInCellsX() != count_x_ ||
-      parent->getSizeInCellsY() != count_y_ ||
-      parent->getResolution() != resolution_;
+    bool geometry_changed;
+    {
+      // count_x_/count_y_/resolution_ are written under costmap_mutex_ in
+      // matchSize(); read them under the same lock here so the geometry-change
+      // detection can't tear against a concurrent matchSize() invocation.
+      std::lock_guard<std::mutex> lock(costmap_mutex_);
+      geometry_changed =
+        parent->getSizeInCellsX() != count_x_ ||
+        parent->getSizeInCellsY() != count_y_ ||
+        parent->getResolution() != resolution_;
+    }
 
     if (geometry_changed) {
       matchSize();  // recreate the buffer at the new size/resolution (locks internally)
@@ -169,6 +176,23 @@ public:
       size_x, size_y, resolution_, parentCenter(parent), params_);
     RCLCPP_INFO_STREAM(
       logger_, "SeaSurfaceLayer occupancy buffer sized to " << count_x_ << "x" << count_y_);
+
+    // The projection AABB has half-extent = maximum_range_ centred on the
+    // camera; the buffer rolls with the parent costmap (half-extent ≈
+    // min(size_x, size_y) / 2). When the camera is centred in the buffer,
+    // observations past the buffer's half-extent project successfully but
+    // grid_map drops them at write time. Surface the mismatch so the operator
+    // can either raise the parent costmap size or lower maximum_range_; the
+    // layer doesn't silently clamp (would mis-report effective reach).
+    const double buffer_half_extent = std::min(size_x, size_y) / 2.0;
+    if (maximum_range_ > buffer_half_extent) {
+      RCLCPP_WARN_STREAM(
+        logger_,
+        "SeaSurfaceLayer maximum_range " << maximum_range_ << " m exceeds buffer "
+          "half-extent " << buffer_half_extent << " m (parent costmap " << size_x
+          << "x" << size_y << " m). Observations past the buffer edge will be "
+          "dropped; raise the costmap size or lower maximum_range.");
+    }
   }
 
 private:
@@ -220,6 +244,12 @@ private:
       // tide (see #19 / #10 H). Phase 3 of #19 restores the pre-#19 inverse
       // direction; see the offline `bag_to_costmap_video` for the A/B that drove
       // the change.
+      //
+      // TODO(#19, phase >5): the square AABB over-iterates by ~21% relative to
+      // the inscribed Euclidean range gate, and many cells project off-image or
+      // behind the camera. A per-camera FOV-cone cull (using the pinhole
+      // model's image bounds + the camera pose) would prune those before
+      // projection — meaningful CPU once we sustain N>1 cameras (phase 4).
       const auto observations = sea_surface_segmentation::project_observations_inverse(
         image->image, *camera_model, camera_origin, rotation_cam_to_world,
         maximum_range_, camera_origin[0], camera_origin[1], res, maximum_range_, 0.0);
@@ -236,8 +266,24 @@ private:
           buffer_->miss(p);
         }
       }
+      // Mark the layer current so LayeredCostmap::isCurrent() doesn't report a
+      // stale layer once a frame has been ingested. Stays true once set — the
+      // layer's persistence-and-decay semantics mean an unmodified buffer is
+      // still up-to-date (decay runs in updateBounds every cycle).
+      current_ = true;
     } catch (const std::exception & e) {
-      RCLCPP_WARN_STREAM(logger_, e.what());
+      if (auto node = node_.lock()) {
+        // Throttle: a stuck TF or wrong-encoding image floods at the
+        // segmentation publish rate (~5 Hz / camera × N cameras). Include the
+        // source frame and stamp so the log line is self-diagnostic.
+        auto clock = node->get_clock();
+        RCLCPP_WARN_THROTTLE(
+          logger_, *clock, 5000,
+          "SeaSurfaceLayer projection failed for %s @ %d.%09d: %s",
+          segments_msg->header.frame_id.c_str(),
+          segments_msg->header.stamp.sec, segments_msg->header.stamp.nanosec,
+          e.what());
+      }
     }
   }
 

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -11,6 +11,7 @@
 #include "image_geometry/pinhole_camera_model.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
+#include "rclcpp/exceptions/exceptions.hpp"
 #include "rclcpp/parameter.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
@@ -98,10 +99,11 @@ public:
       // Back-compat: pre-#19 single-source configuration.
       declareParameter("segmentation_topic", rclcpp::ParameterValue(std::string("segmentation")));
       declareParameter("camera_info_topic", rclcpp::ParameterValue(std::string("camera_info")));
-      std::string seg, info;
-      node->get_parameter(name_ + ".segmentation_topic", seg);
-      node->get_parameter(name_ + ".camera_info_topic", info);
-      sources_.push_back(std::make_unique<Source>(Source{"default", seg, info, {}, {}, {}}));
+      auto src = std::make_unique<Source>();
+      src->name = "default";
+      node->get_parameter(name_ + ".segmentation_topic", src->segmentation_topic);
+      node->get_parameter(name_ + ".camera_info_topic", src->camera_info_topic);
+      sources_.push_back(std::move(src));
     } else {
       // Multi-source: one (segmentation, camera_info) pair per named source.
       // All sources feed the shared world-frame buffer, so a single obstacle
@@ -110,17 +112,18 @@ public:
       for (const auto & name : source_names) {
         declareParameter(name + ".segmentation_topic", rclcpp::ParameterValue(std::string{}));
         declareParameter(name + ".camera_info_topic", rclcpp::ParameterValue(std::string{}));
-        std::string seg, info;
-        node->get_parameter(name_ + "." + name + ".segmentation_topic", seg);
-        node->get_parameter(name_ + "." + name + ".camera_info_topic", info);
-        if (seg.empty() || info.empty()) {
+        auto src = std::make_unique<Source>();
+        src->name = name;
+        node->get_parameter(name_ + "." + name + ".segmentation_topic", src->segmentation_topic);
+        node->get_parameter(name_ + "." + name + ".camera_info_topic", src->camera_info_topic);
+        if (src->segmentation_topic.empty() || src->camera_info_topic.empty()) {
           RCLCPP_ERROR_STREAM(
             logger_,
             "SeaSurfaceLayer source '" << name << "' is missing segmentation_topic "
               "or camera_info_topic — skipping");
           continue;
         }
-        sources_.push_back(std::make_unique<Source>(Source{name, seg, info, {}, {}, {}}));
+        sources_.push_back(std::move(src));
       }
     }
 
@@ -429,39 +432,56 @@ private:
     if (!node) {
       return;
     }
-    nav_msgs::msg::OccupancyGrid msg;
-    msg.header.stamp = node->now();
-    msg.header.frame_id = global_frame_id_;
 
+    // Snapshot pattern: copy the grid_map under the lock, walk it off-lock.
+    // The O(W*H) per-cell scan (~40k Eigen reads on a 200×200 buffer) would
+    // otherwise serialize against every segmentsCallback wanting to write a
+    // hit/miss. The copy is one Eigen MatrixXf deep-copy (≈ width*height*4 B
+    // — 160 kB on the same 200×200) — far cheaper than holding the lock
+    // through the scan.
+    grid_map::GridMap map_copy;
+    double threshold;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       if (!buffer_) {
         return;
       }
-      const auto & map = buffer_->map();
-      const auto size = map.getSize();
-      const auto center = map.getPosition();
-      msg.info.resolution = static_cast<float>(map.getResolution());
-      msg.info.width = static_cast<uint32_t>(size(0));
-      msg.info.height = static_cast<uint32_t>(size(1));
-      // grid_map is positioned by its center; OccupancyGrid origin is the
-      // lower-left corner of cell (0, 0).
-      msg.info.origin.position.x = center(0) - 0.5 * size(0) * map.getResolution();
-      msg.info.origin.position.y = center(1) - 0.5 * size(1) * map.getResolution();
-      msg.info.origin.position.z = 0.0;
-      msg.info.origin.orientation.w = 1.0;
-      msg.data.assign(static_cast<size_t>(size(0)) * size(1), -1);
+      map_copy = buffer_->map();  // grid_map copy assignment = deep copy of Eigen data
+      threshold = params_.lethal_threshold;
+    }
 
-      // Walk OccupancyGrid cells in row-major order; for each cell's world
-      // position, query the buffer's lethal test. Avoids dancing through
-      // grid_map's column-major / circular-buffer index layout.
-      for (uint32_t y = 0; y < msg.info.height; ++y) {
-        for (uint32_t x = 0; x < msg.info.width; ++x) {
-          const double wx = msg.info.origin.position.x + (x + 0.5) * msg.info.resolution;
-          const double wy = msg.info.origin.position.y + (y + 0.5) * msg.info.resolution;
-          if (buffer_->isLethal(grid_map::Position(wx, wy))) {
-            msg.data[static_cast<size_t>(y) * msg.info.width + x] = 100;
-          }
+    nav_msgs::msg::OccupancyGrid msg;
+    msg.header.stamp = node->now();
+    msg.header.frame_id = global_frame_id_;
+
+    const auto size = map_copy.getSize();
+    const auto center = map_copy.getPosition();
+    msg.info.resolution = static_cast<float>(map_copy.getResolution());
+    msg.info.width = static_cast<uint32_t>(size(0));
+    msg.info.height = static_cast<uint32_t>(size(1));
+    // grid_map is positioned by its center; OccupancyGrid origin is the
+    // lower-left corner of cell (0, 0).
+    msg.info.origin.position.x = center(0) - 0.5 * size(0) * map_copy.getResolution();
+    msg.info.origin.position.y = center(1) - 0.5 * size(1) * map_copy.getResolution();
+    msg.info.origin.position.z = 0.0;
+    msg.info.origin.orientation.w = 1.0;
+    msg.data.assign(static_cast<size_t>(size(0)) * size(1), -1);
+
+    // Walk OccupancyGrid cells in row-major order; for each cell's world
+    // position, query the snapshot copy. Walking by world position rather
+    // than direct index avoids dancing through grid_map's column-major /
+    // circular-buffer index layout.
+    for (uint32_t y = 0; y < msg.info.height; ++y) {
+      for (uint32_t x = 0; x < msg.info.width; ++x) {
+        const double wx = msg.info.origin.position.x + (x + 0.5) * msg.info.resolution;
+        const double wy = msg.info.origin.position.y + (y + 0.5) * msg.info.resolution;
+        const grid_map::Position p(wx, wy);
+        if (!map_copy.isInside(p)) {
+          continue;
+        }
+        const float v = map_copy.atPosition("log_odds", p);
+        if (std::isfinite(v) && static_cast<double>(v) >= threshold) {
+          msg.data[static_cast<size_t>(y) * msg.info.width + x] = 100;
         }
       }
     }
@@ -493,27 +513,71 @@ private:
       candidate_max_range = maximum_range_;
     }
 
-    for (const auto & p : params) {
-      const auto & n = p.get_name();
-      if (n == name_ + ".hit_log_odds") {
-        candidate_occ.hit_log_odds = p.as_double();
-      } else if (n == name_ + ".miss_log_odds") {
-        candidate_occ.miss_log_odds = p.as_double();
-      } else if (n == name_ + ".clamp") {
-        candidate_occ.clamp = p.as_double();
-      } else if (n == name_ + ".lethal_threshold") {
-        candidate_occ.lethal_threshold = p.as_double();
-      } else if (n == name_ + ".decay_half_life_s") {
-        candidate_occ.decay_half_life_s = p.as_double();
-      } else if (n == name_ + ".maximum_range") {
-        const double v = p.as_double();
-        if (!std::isfinite(v) || v <= 0.0) {
+    // Configure-time params — subscriber re-bind / publisher re-bind isn't
+    // supported here, so accepting these silently would leave the parameter
+    // store updated but the wiring stale (the operator's #10-K failure mode
+    // in a different disguise). Reject with a clear message instead. Each
+    // entry is matched as a suffix that may appear top-level (e.g.
+    // `<layer>.observation_sources`) OR per-source (e.g.
+    // `<layer>.<source>.segmentation_topic`).
+    const std::vector<std::string> configure_time_suffixes{
+      ".observation_sources", ".segmentation_topic", ".camera_info_topic",
+      ".published_topic"};
+
+    auto is_configure_time = [&](const std::string & n) {
+      if (n.find(name_ + ".") != 0) {
+        return false;  // not one of this layer's params
+      }
+      for (const auto & suffix : configure_time_suffixes) {
+        if (n.size() >= suffix.size() &&
+          n.compare(n.size() - suffix.size(), suffix.size(), suffix) == 0)
+        {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    // `as_double()` raises rclcpp::exceptions::InvalidParameterTypeException
+    // when the parameter is set to a non-double value (e.g. a bool or string).
+    // That exception would propagate out of the parameter service thread and
+    // crash the node; wrap the dispatch so a wrong-type set returns a clean
+    // SetParametersResult{successful=false, reason=…} instead.
+    try {
+      for (const auto & p : params) {
+        const auto & n = p.get_name();
+
+        if (is_configure_time(n)) {
           result.successful = false;
-          result.reason = "maximum_range must be finite and > 0";
+          result.reason = n + " is configure-time only (subscriber/publisher "
+            "re-bind is not supported); restart the costmap to apply";
           return result;
         }
-        candidate_max_range = v;
+
+        if (n == name_ + ".hit_log_odds") {
+          candidate_occ.hit_log_odds = p.as_double();
+        } else if (n == name_ + ".miss_log_odds") {
+          candidate_occ.miss_log_odds = p.as_double();
+        } else if (n == name_ + ".clamp") {
+          candidate_occ.clamp = p.as_double();
+        } else if (n == name_ + ".lethal_threshold") {
+          candidate_occ.lethal_threshold = p.as_double();
+        } else if (n == name_ + ".decay_half_life_s") {
+          candidate_occ.decay_half_life_s = p.as_double();
+        } else if (n == name_ + ".maximum_range") {
+          const double v = p.as_double();
+          if (!std::isfinite(v) || v <= 0.0) {
+            result.successful = false;
+            result.reason = "maximum_range must be finite and > 0";
+            return result;
+          }
+          candidate_max_range = v;
+        }
       }
+    } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
+      result.successful = false;
+      result.reason = std::string("invalid parameter type: ") + e.what();
+      return result;
     }
 
     std::string why;

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -175,15 +175,6 @@ public:
         });
     }
 
-    // Live-tunable params via `ros2 param set` (phase 6). Decay half-life,
-    // hit/miss increments, clamp, lethal threshold, and maximum_range all
-    // reconfigure at runtime; topic and source-list params stay configure-time
-    // (subscriber re-bind is not supported here). The callback validates the
-    // proposed change before applying — a fat-fingered set can't silently
-    // poison the buffer interpretation.
-    param_callback_handle_ = node->add_on_set_parameters_callback(
-      std::bind(&SeaSurfaceLayer::onParametersSet, this, std::placeholders::_1));
-
     // Optional publish-and-relay: when `published_topic` is non-empty, the
     // layer republishes its lethal cells as a nav_msgs/OccupancyGrid on that
     // topic so the companion `SeaSurfaceRelayLayer` (in global_costmap) can
@@ -198,6 +189,22 @@ public:
       RCLCPP_INFO_STREAM(
         logger_, "SeaSurfaceLayer publishing lethal grid on '" << published_topic_ << "'");
     }
+
+    // Live-tunable params via `ros2 param set` (phase 6). Decay half-life,
+    // hit/miss increments, clamp, lethal threshold, and maximum_range all
+    // reconfigure at runtime; topic and source-list params stay configure-time
+    // (subscriber re-bind is not supported here). The callback validates the
+    // proposed change before applying — a fat-fingered set can't silently
+    // poison the buffer interpretation.
+    //
+    // IMPORTANT: must register AFTER every `declareParameter` above. rclcpp
+    // invokes on-set-parameters callbacks for the initial-value validation
+    // inside `declare_parameter`; if a configure-time param (e.g.
+    // `.published_topic`) were declared after this point, the callback's
+    // `is_configure_time` rejection would throw `InvalidParameterValueException`
+    // and abort `onInitialize` — the layer would fail to load.
+    param_callback_handle_ = node->add_on_set_parameters_callback(
+      std::bind(&SeaSurfaceLayer::onParametersSet, this, std::placeholders::_1));
   }
 
   void reset() override
@@ -216,24 +223,29 @@ public:
     double robot_x, double robot_y, double /*robot_yaw*/,
     double * min_x, double * min_y, double * max_x, double * max_y) override
   {
-    // Expand (don't clobber) the master bounds so earlier layers' contributions survive.
-    *min_x = std::min(*min_x, robot_x - maximum_range_);
-    *min_y = std::min(*min_y, robot_y - maximum_range_);
-    *max_x = std::max(*max_x, robot_x + maximum_range_);
-    *max_y = std::max(*max_y, robot_y + maximum_range_);
-
+    // Snapshot the live-tunable scalars + parent-geometry tracking under the
+    // lock. `maximum_range_` is written by the parameter callback under the
+    // same lock; the 4 bound-expansion reads below would otherwise race a
+    // concurrent `ros2 param set`. `count_x_/count_y_/resolution_` are written
+    // under the lock in `matchSize()`; reading them here under the lock keeps
+    // the geometry-change detection from tearing.
     auto parent = layered_costmap_->getCostmap();
+    double maximum_range;
     bool geometry_changed;
     {
-      // count_x_/count_y_/resolution_ are written under costmap_mutex_ in
-      // matchSize(); read them under the same lock here so the geometry-change
-      // detection can't tear against a concurrent matchSize() invocation.
       std::lock_guard<std::mutex> lock(costmap_mutex_);
+      maximum_range = maximum_range_;
       geometry_changed =
         parent->getSizeInCellsX() != count_x_ ||
         parent->getSizeInCellsY() != count_y_ ||
         parent->getResolution() != resolution_;
     }
+
+    // Expand (don't clobber) the master bounds so earlier layers' contributions survive.
+    *min_x = std::min(*min_x, robot_x - maximum_range);
+    *min_y = std::min(*min_y, robot_y - maximum_range);
+    *max_x = std::max(*max_x, robot_x + maximum_range);
+    *max_y = std::max(*max_y, robot_y + maximum_range);
 
     if (geometry_changed) {
       matchSize();  // recreate the buffer at the new size/resolution (locks internally)

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -8,6 +8,8 @@
 
 #include "cv_bridge/cv_bridge.hpp"
 #include "image_geometry/pinhole_camera_model.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+#include "rclcpp/parameter.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "nav2_costmap_2d/cost_values.hpp"
@@ -79,6 +81,15 @@ public:
     camera_info_subscriber_ = node->create_subscription<sensor_msgs::msg::CameraInfo>(
       camera_info_topic, rclcpp::SensorDataQoS(),
       std::bind(&SeaSurfaceLayer::cameraInfoCallback, this, std::placeholders::_1));
+
+    // Live-tunable params via `ros2 param set` (phase 6). Decay half-life,
+    // hit/miss increments, clamp, lethal threshold, and maximum_range all
+    // reconfigure at runtime; topic and source-list params stay configure-time
+    // (subscriber re-bind is not supported here). The callback validates the
+    // proposed change before applying — a fat-fingered set can't silently
+    // poison the buffer interpretation.
+    param_callback_handle_ = node->add_on_set_parameters_callback(
+      std::bind(&SeaSurfaceLayer::onParametersSet, this, std::placeholders::_1));
   }
 
   void reset() override
@@ -298,6 +309,69 @@ private:
     camera_model_ = model;
   }
 
+  // Validate-then-apply param updates. Runs on the parameter service thread.
+  // Builds a candidate copy of the live-tunable state from `params` (each named
+  // entry overrides the candidate field), validates the candidate (NaN /
+  // out-of-range / safety inversions are rejected via OccupancyBuffer::validate
+  // + a maximum_range > 0 check), and only on success swaps into the live state
+  // under `costmap_mutex_`. The buffer reinterprets accumulated evidence
+  // against the new threshold/clamp immediately; new increments and decay rate
+  // take effect on the next update cycle. Unknown / configure-time params
+  // (topics) pass through as a no-op so the parameter store can still record
+  // them.
+  rcl_interfaces::msg::SetParametersResult onParametersSet(
+    const std::vector<rclcpp::Parameter> & params)
+  {
+    rcl_interfaces::msg::SetParametersResult result;
+    result.successful = true;
+
+    sea_surface_segmentation::OccupancyParams candidate_occ;
+    double candidate_max_range;
+    {
+      std::lock_guard<std::mutex> lock(costmap_mutex_);
+      candidate_occ = params_;
+      candidate_max_range = maximum_range_;
+    }
+
+    for (const auto & p : params) {
+      const auto & n = p.get_name();
+      if (n == name_ + ".hit_log_odds") {
+        candidate_occ.hit_log_odds = p.as_double();
+      } else if (n == name_ + ".miss_log_odds") {
+        candidate_occ.miss_log_odds = p.as_double();
+      } else if (n == name_ + ".clamp") {
+        candidate_occ.clamp = p.as_double();
+      } else if (n == name_ + ".lethal_threshold") {
+        candidate_occ.lethal_threshold = p.as_double();
+      } else if (n == name_ + ".decay_half_life_s") {
+        candidate_occ.decay_half_life_s = p.as_double();
+      } else if (n == name_ + ".maximum_range") {
+        const double v = p.as_double();
+        if (!std::isfinite(v) || v <= 0.0) {
+          result.successful = false;
+          result.reason = "maximum_range must be finite and > 0";
+          return result;
+        }
+        candidate_max_range = v;
+      }
+    }
+
+    std::string why;
+    if (!sea_surface_segmentation::OccupancyBuffer::validate(candidate_occ, why)) {
+      result.successful = false;
+      result.reason = why;
+      return result;
+    }
+
+    std::lock_guard<std::mutex> lock(costmap_mutex_);
+    params_ = candidate_occ;
+    maximum_range_ = candidate_max_range;
+    if (buffer_) {
+      buffer_->setParams(params_);
+    }
+    return result;
+  }
+
   std::string global_frame_id_;
 
   // Parent-costmap geometry tracking (to detect true size/resolution changes
@@ -316,6 +390,8 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_subscriber_;
 
   std::shared_ptr<image_geometry::PinholeCameraModel> camera_model_;
+
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 
   std::mutex costmap_mutex_;
 };

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -19,10 +19,11 @@ namespace sea_surface_layer
 
 // Costmap layer that fuses camera segmentation into a persistent, decaying
 // log-odds occupancy buffer (see occupancy_buffer.hpp). Each segmentation frame
-// contributes ground-plane observations via project_observations (waterline
-// contact → obstacle, water → free, occluded body → skipped); the buffer
-// remembers obstacles through gaps and forgets them over time. Phase 1+3 of
-// #19; still single-source (multi-camera fusion is phase 4).
+// contributes ground-plane observations via `project_observations_inverse`
+// (iterate world cells in the camera's reach, classify each by the pixel it
+// covers: waterline contact → hit, water → miss, occluded body / sky → skip);
+// the buffer remembers obstacles through gaps and forgets them over time.
+// Phase 1+3 of #19; still single-source (multi-camera fusion is phase 4).
 class SeaSurfaceLayer: public nav2_costmap_2d::Layer
 {
 public:
@@ -179,15 +180,19 @@ private:
 
   void segmentsCallback(const sensor_msgs::msg::Image::SharedPtr segments_msg)
   {
-    // Pin the camera model under the lock, then project off-lock. cameraInfoCallback
-    // swaps in a *fresh* model (never mutates in place), so this local copy is an
-    // immutable snapshot — no torn read / use-after-free during projection.
+    // Pin the camera model + buffer geometry under the lock, then project off-lock.
+    // cameraInfoCallback swaps in a *fresh* model (never mutates in place), so this
+    // local copy is an immutable snapshot — no torn read / use-after-free during
+    // projection. `resolution_` is captured here too because matchSize() can update
+    // it from updateBounds(); reading it inside the off-lock projection would race.
     std::shared_ptr<image_geometry::PinholeCameraModel> camera_model;
+    double res;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       camera_model = camera_model_;
+      res = resolution_;
     }
-    if (!camera_model) {
+    if (!camera_model || res <= 0.0) {
       return;
     }
     try {
@@ -204,10 +209,17 @@ private:
       const cv::Matx33d rotation_cam_to_world =
         sea_surface_segmentation::rotation_matrix_from_quaternion(q.x, q.y, q.z, q.w);
 
-      // Water surface is z=0 in the tide-tracked global frame; the boat floats,
-      // so this holds at any tide (see #19 / #10 H discussion).
-      const auto observations = sea_surface_segmentation::project_observations(
-        image->image, *camera_model, camera_origin, rotation_cam_to_world, maximum_range_, 0.0);
+      // INVERSE (cell→pixel) projection — iterate the world cells this camera can
+      // reach (square AABB of half-width `maximum_range_` centred on the camera's
+      // XY) and classify each by the pixel it covers. Fills each pixel's full
+      // footprint (no gaps) and is naturally range-bounded. Water surface is z=0
+      // in the tide-tracked global frame; the boat floats, so this holds at any
+      // tide (see #19 / #10 H). Phase 3 of #19 restores the pre-#19 inverse
+      // direction; see the offline `bag_to_costmap_video` for the A/B that drove
+      // the change.
+      const auto observations = sea_surface_segmentation::project_observations_inverse(
+        image->image, *camera_model, camera_origin, rotation_cam_to_world,
+        maximum_range_, camera_origin[0], camera_origin[1], res, maximum_range_, 0.0);
 
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       if (!buffer_) {

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include "cv_bridge/cv_bridge.hpp"
 #include "image_geometry/pinhole_camera_model.hpp"
@@ -22,15 +23,41 @@
 namespace sea_surface_layer
 {
 
-// Costmap layer that fuses camera segmentation into a persistent, decaying
-// log-odds occupancy buffer (see occupancy_buffer.hpp). Each segmentation frame
-// contributes ground-plane observations via `project_observations_inverse`
-// (iterate world cells in the camera's reach, classify each by the pixel it
-// covers: waterline contact → hit, water → miss, occluded body / sky → skip);
-// the buffer remembers obstacles through gaps and forgets them over time.
-// Phase 1+3 of #19; still single-source (multi-camera fusion is phase 4).
+// Costmap layer that fuses one OR MORE camera segmentation streams into a
+// shared persistent, decaying log-odds occupancy buffer (see
+// occupancy_buffer.hpp). Each segmentation frame contributes ground-plane
+// observations via `project_observations_inverse` (iterate world cells in the
+// camera's reach, classify each by the pixel it covers: waterline contact →
+// hit, water → miss, occluded body / sky → skip); the buffer remembers
+// obstacles through gaps, forgets them over time, and accumulates evidence
+// from overlapping cameras into the same world cell. Phases 1, 3, 4 of #19.
+//
+// Sources are configured via `observation_sources` (a vector of string names);
+// each source has `<name>.segmentation_topic` and `<name>.camera_info_topic`.
+// When `observation_sources` is empty, the layer falls back to the legacy
+// top-level `segmentation_topic` / `camera_info_topic` as a single source
+// named "default" — pre-#19 configs work unchanged.
 class SeaSurfaceLayer: public nav2_costmap_2d::Layer
 {
+private:
+  // Per-source state — one per configured observation source. Defined here so
+  // the per-callback `Source &` parameter types resolve below.
+  //
+  // Stored as `unique_ptr<Source>` (not raw `Source`) so the address stays
+  // stable for the lifetime of the layer: the subscriptions capture `Source *`
+  // in their lambdas, and `sources_` would otherwise reallocate-and-invalidate
+  // those pointers if grown after onInitialize. The vector is built once and
+  // not modified after onInitialize completes.
+  struct Source
+  {
+    std::string name;
+    std::string segmentation_topic;
+    std::string camera_info_topic;
+    rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr seg_sub;
+    rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr info_sub;
+    std::shared_ptr<image_geometry::PinholeCameraModel> camera_model;
+  };
+
 public:
   SeaSurfaceLayer() {}
   ~SeaSurfaceLayer() {}
@@ -61,12 +88,47 @@ public:
       params_ = sea_surface_segmentation::OccupancyParams{};
     }
 
-    declareParameter("segmentation_topic", rclcpp::ParameterValue("segmentation"));
-    std::string segmentation_topic;
-    node->get_parameter(name_ + ".segmentation_topic", segmentation_topic);
-    declareParameter("camera_info_topic", rclcpp::ParameterValue("camera_info"));
-    std::string camera_info_topic;
-    node->get_parameter(name_ + ".camera_info_topic", camera_info_topic);
+    // Source list — empty falls back to single-source legacy config.
+    declareParameter("observation_sources", rclcpp::ParameterValue(std::vector<std::string>{}));
+    std::vector<std::string> source_names;
+    node->get_parameter(name_ + ".observation_sources", source_names);
+
+    if (source_names.empty()) {
+      // Back-compat: pre-#19 single-source configuration.
+      declareParameter("segmentation_topic", rclcpp::ParameterValue(std::string("segmentation")));
+      declareParameter("camera_info_topic", rclcpp::ParameterValue(std::string("camera_info")));
+      std::string seg, info;
+      node->get_parameter(name_ + ".segmentation_topic", seg);
+      node->get_parameter(name_ + ".camera_info_topic", info);
+      sources_.push_back(std::make_unique<Source>(Source{"default", seg, info, {}, {}, {}}));
+    } else {
+      // Multi-source: one (segmentation, camera_info) pair per named source.
+      // All sources feed the shared world-frame buffer, so a single obstacle
+      // in the overlap region accumulates evidence from every camera that
+      // sees it — the multi-camera fusion the per-camera layers couldn't do.
+      for (const auto & name : source_names) {
+        declareParameter(name + ".segmentation_topic", rclcpp::ParameterValue(std::string{}));
+        declareParameter(name + ".camera_info_topic", rclcpp::ParameterValue(std::string{}));
+        std::string seg, info;
+        node->get_parameter(name_ + "." + name + ".segmentation_topic", seg);
+        node->get_parameter(name_ + "." + name + ".camera_info_topic", info);
+        if (seg.empty() || info.empty()) {
+          RCLCPP_ERROR_STREAM(
+            logger_,
+            "SeaSurfaceLayer source '" << name << "' is missing segmentation_topic "
+              "or camera_info_topic — skipping");
+          continue;
+        }
+        sources_.push_back(std::make_unique<Source>(Source{name, seg, info, {}, {}, {}}));
+      }
+    }
+
+    if (sources_.empty()) {
+      RCLCPP_WARN_STREAM(
+        logger_,
+        "SeaSurfaceLayer: no observation sources configured; layer will not "
+        "ingest any segmentation frames");
+    }
 
     global_frame_id_ = layered_costmap_->getGlobalFrameID();
 
@@ -74,13 +136,23 @@ public:
     // message can't dispatch segmentsCallback against a null buffer_.
     matchSize();
 
-    segments_subscriber_ = node->create_subscription<sensor_msgs::msg::Image>(
-      segmentation_topic, rclcpp::SensorDataQoS(),
-      std::bind(&SeaSurfaceLayer::segmentsCallback, this, std::placeholders::_1));
-
-    camera_info_subscriber_ = node->create_subscription<sensor_msgs::msg::CameraInfo>(
-      camera_info_topic, rclcpp::SensorDataQoS(),
-      std::bind(&SeaSurfaceLayer::cameraInfoCallback, this, std::placeholders::_1));
+    for (auto & src_uptr : sources_) {
+      // Capture the raw pointer in the lambda (Source's address is stable for
+      // the lifetime of sources_; unique_ptr only moves when the vector is
+      // modified, which we don't do after onInitialize). The Source struct
+      // outlives the subscriptions because the subs are members of it.
+      Source * src = src_uptr.get();
+      src->seg_sub = node->create_subscription<sensor_msgs::msg::Image>(
+        src->segmentation_topic, rclcpp::SensorDataQoS(),
+        [this, src](sensor_msgs::msg::Image::SharedPtr msg) {
+          segmentsCallback(*src, msg);
+        });
+      src->info_sub = node->create_subscription<sensor_msgs::msg::CameraInfo>(
+        src->camera_info_topic, rclcpp::SensorDataQoS(),
+        [this, src](sensor_msgs::msg::CameraInfo::SharedPtr msg) {
+          cameraInfoCallback(*src, msg);
+        });
+    }
 
     // Live-tunable params via `ros2 param set` (phase 6). Decay half-life,
     // hit/miss increments, clamp, lethal threshold, and maximum_range all
@@ -216,18 +288,24 @@ private:
       parent->getOriginY() + parent->getSizeInCellsY() * parent->getResolution() / 2.0);
   }
 
-  void segmentsCallback(const sensor_msgs::msg::Image::SharedPtr segments_msg)
+  // Per-source segmentation callback. `src` is the source that owns this
+  // subscription (captured by raw pointer in onInitialize's lambda); the
+  // shared occupancy buffer accumulates evidence from every source's hits and
+  // misses, so an obstacle in two cameras' overlap gets twice the evidence.
+  void segmentsCallback(
+    Source & src, const sensor_msgs::msg::Image::SharedPtr segments_msg)
   {
-    // Pin the camera model + buffer geometry under the lock, then project off-lock.
-    // cameraInfoCallback swaps in a *fresh* model (never mutates in place), so this
-    // local copy is an immutable snapshot — no torn read / use-after-free during
-    // projection. `resolution_` is captured here too because matchSize() can update
-    // it from updateBounds(); reading it inside the off-lock projection would race.
+    // Pin the per-source camera model + shared buffer geometry under the
+    // lock, then project off-lock. cameraInfoCallback swaps in a *fresh*
+    // model (never mutates in place), so this local copy is an immutable
+    // snapshot — no torn read / use-after-free during projection.
+    // `resolution_` is captured here too because matchSize() can update it
+    // from updateBounds(); reading it inside the off-lock projection would race.
     std::shared_ptr<image_geometry::PinholeCameraModel> camera_model;
     double res;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
-      camera_model = camera_model_;
+      camera_model = src.camera_model;
       res = resolution_;
     }
     if (!camera_model || res <= 0.0) {
@@ -286,11 +364,12 @@ private:
       if (auto node = node_.lock()) {
         // Throttle: a stuck TF or wrong-encoding image floods at the
         // segmentation publish rate (~5 Hz / camera × N cameras). Include the
-        // source frame and stamp so the log line is self-diagnostic.
+        // source name + image frame + stamp so the log line is self-diagnostic.
         auto clock = node->get_clock();
         RCLCPP_WARN_THROTTLE(
           logger_, *clock, 5000,
-          "SeaSurfaceLayer projection failed for %s @ %d.%09d: %s",
+          "SeaSurfaceLayer source '%s' projection failed for %s @ %d.%09d: %s",
+          src.name.c_str(),
           segments_msg->header.frame_id.c_str(),
           segments_msg->header.stamp.sec, segments_msg->header.stamp.nanosec,
           e.what());
@@ -298,7 +377,11 @@ private:
     }
   }
 
-  void cameraInfoCallback(const sensor_msgs::msg::CameraInfo::SharedPtr camera_info_msg)
+  // Per-source camera_info callback. Updates the source's own camera model;
+  // each source carries its own intrinsics (the 4-camera config has different
+  // optics per direction, e.g. forward narrow-FOV vs side wide-FOV).
+  void cameraInfoCallback(
+    Source & src, const sensor_msgs::msg::CameraInfo::SharedPtr camera_info_msg)
   {
     // Build a fresh model off-lock, then swap the pointer under the lock. Readers
     // that already copied the old pointer keep using an unchanged object — no
@@ -306,7 +389,7 @@ private:
     auto model = std::make_shared<image_geometry::PinholeCameraModel>();
     model->fromCameraInfo(*camera_info_msg);
     std::lock_guard<std::mutex> lock(costmap_mutex_);
-    camera_model_ = model;
+    src.camera_model = model;
   }
 
   // Validate-then-apply param updates. Runs on the parameter service thread.
@@ -386,10 +469,7 @@ private:
   sea_surface_segmentation::OccupancyParams params_;
   std::unique_ptr<sea_surface_segmentation::OccupancyBuffer> buffer_;
 
-  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr segments_subscriber_;
-  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_subscriber_;
-
-  std::shared_ptr<image_geometry::PinholeCameraModel> camera_model_;
+  std::vector<std::unique_ptr<Source>> sources_;
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -1,6 +1,9 @@
 
 #include <algorithm>
+#include <chrono>
+#include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "cv_bridge/cv_bridge.hpp"

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -179,7 +179,15 @@ private:
 
   void segmentsCallback(const sensor_msgs::msg::Image::SharedPtr segments_msg)
   {
-    if (!camera_model_) {
+    // Pin the camera model under the lock, then project off-lock. cameraInfoCallback
+    // swaps in a *fresh* model (never mutates in place), so this local copy is an
+    // immutable snapshot — no torn read / use-after-free during projection.
+    std::shared_ptr<image_geometry::PinholeCameraModel> camera_model;
+    {
+      std::lock_guard<std::mutex> lock(costmap_mutex_);
+      camera_model = camera_model_;
+    }
+    if (!camera_model) {
       return;
     }
     try {
@@ -199,7 +207,7 @@ private:
       // Water surface is z=0 in the tide-tracked global frame; the boat floats,
       // so this holds at any tide (see #19 / #10 H discussion).
       const auto observations = sea_surface_segmentation::project_observations(
-        image->image, *camera_model_, camera_origin, rotation_cam_to_world, maximum_range_, 0.0);
+        image->image, *camera_model, camera_origin, rotation_cam_to_world, maximum_range_, 0.0);
 
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       if (!buffer_) {
@@ -220,12 +228,13 @@ private:
 
   void cameraInfoCallback(const sensor_msgs::msg::CameraInfo::SharedPtr camera_info_msg)
   {
+    // Build a fresh model off-lock, then swap the pointer under the lock. Readers
+    // that already copied the old pointer keep using an unchanged object — no
+    // in-place mutation of a model a concurrent segmentsCallback may be reading.
+    auto model = std::make_shared<image_geometry::PinholeCameraModel>();
+    model->fromCameraInfo(*camera_info_msg);
     std::lock_guard<std::mutex> lock(costmap_mutex_);
-    camera_info_ = *camera_info_msg;
-    if (!camera_model_) {
-      camera_model_ = std::make_shared<image_geometry::PinholeCameraModel>();
-    }
-    camera_model_->fromCameraInfo(camera_info_);
+    camera_model_ = model;
   }
 
   std::string global_frame_id_;
@@ -245,7 +254,6 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr segments_subscriber_;
   rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_subscriber_;
 
-  sensor_msgs::msg::CameraInfo camera_info_;
   std::shared_ptr<image_geometry::PinholeCameraModel> camera_model_;
 
   std::mutex costmap_mutex_;

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -71,6 +71,23 @@ public:
     declareParameter("maximum_range", rclcpp::ParameterValue(maximum_range_));
     node->get_parameter(name_ + ".maximum_range", maximum_range_);
 
+    // Reject rays whose grazing angle to the water plane is below this — they
+    // back-project to large ground errors per arc-second of pitch and dominate
+    // long-range noise. Camera height bounds the cut: a camera at height h
+    // enforces max horizontal reach ≈ h / tan(min_grazing). Default 0 = off.
+    declareParameter(
+      "min_grazing_angle_deg", rclcpp::ParameterValue(min_grazing_angle_deg_));
+    node->get_parameter(name_ + ".min_grazing_angle_deg", min_grazing_angle_deg_);
+    if (!std::isfinite(min_grazing_angle_deg_) ||
+      min_grazing_angle_deg_ < 0.0 || min_grazing_angle_deg_ >= 90.0)
+    {
+      RCLCPP_WARN_STREAM(
+        logger_,
+        "Invalid min_grazing_angle_deg (" << min_grazing_angle_deg_
+          << "); must be in [0, 90). Using 0 (filter off).");
+      min_grazing_angle_deg_ = 0.0;
+    }
+
     // Log-odds occupancy parameters (runtime-tunable wiring is phase 6).
     declareParameter("hit_log_odds", rclcpp::ParameterValue(params_.hit_log_odds));
     node->get_parameter(name_ + ".hit_log_odds", params_.hit_log_odds);
@@ -327,10 +344,14 @@ private:
     // from updateBounds(); reading it inside the off-lock projection would race.
     std::shared_ptr<image_geometry::PinholeCameraModel> camera_model;
     double res;
+    double maximum_range;
+    double min_grazing_deg;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       camera_model = src.camera_model;
       res = resolution_;
+      maximum_range = maximum_range_;
+      min_grazing_deg = min_grazing_angle_deg_;
     }
     if (!camera_model || res <= 0.0) {
       return;
@@ -365,7 +386,8 @@ private:
       // projection — meaningful CPU once we sustain N>1 cameras (phase 4).
       const auto observations = sea_surface_segmentation::project_observations_inverse(
         image->image, *camera_model, camera_origin, rotation_cam_to_world,
-        maximum_range_, camera_origin[0], camera_origin[1], res, maximum_range_, 0.0);
+        maximum_range, camera_origin[0], camera_origin[1], res, maximum_range,
+        /*plane_z=*/0.0, min_grazing_deg);
 
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       if (!buffer_) {
@@ -507,10 +529,12 @@ private:
 
     sea_surface_segmentation::OccupancyParams candidate_occ;
     double candidate_max_range;
+    double candidate_min_grazing_deg;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       candidate_occ = params_;
       candidate_max_range = maximum_range_;
+      candidate_min_grazing_deg = min_grazing_angle_deg_;
     }
 
     // Configure-time params — subscriber re-bind / publisher re-bind isn't
@@ -572,6 +596,14 @@ private:
             return result;
           }
           candidate_max_range = v;
+        } else if (n == name_ + ".min_grazing_angle_deg") {
+          const double v = p.as_double();
+          if (!std::isfinite(v) || v < 0.0 || v >= 90.0) {
+            result.successful = false;
+            result.reason = "min_grazing_angle_deg must be finite and in [0, 90)";
+            return result;
+          }
+          candidate_min_grazing_deg = v;
         }
       }
     } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
@@ -590,6 +622,7 @@ private:
     std::lock_guard<std::mutex> lock(costmap_mutex_);
     params_ = candidate_occ;
     maximum_range_ = candidate_max_range;
+    min_grazing_angle_deg_ = candidate_min_grazing_deg;
     if (buffer_) {
       buffer_->setParams(params_);
     }
@@ -607,6 +640,7 @@ private:
   unsigned int count_y_ = 0;
 
   double maximum_range_ = 100.0;
+  double min_grazing_angle_deg_ = 0.0;  // 0 = filter off (back-compat)
   sea_surface_segmentation::OccupancyParams params_;
   std::unique_ptr<sea_surface_segmentation::OccupancyBuffer> buffer_;
 

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -1,123 +1,156 @@
 
 #include <algorithm>
+#include <memory>
+#include <string>
 
 #include "cv_bridge/cv_bridge.hpp"
-#include "geometry_msgs/msg/point_stamped.hpp"
 #include "image_geometry/pinhole_camera_model.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
+#include "nav2_costmap_2d/cost_values.hpp"
 #include "nav2_costmap_2d/layer.hpp"
 #include "nav2_costmap_2d/layered_costmap.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
-#include "segments_apply.hpp"
+#include "occupancy_buffer.hpp"
 #include "segments_projection.hpp"
 
 namespace sea_surface_layer
 {
 
+// Costmap layer that fuses camera segmentation into a persistent, decaying
+// log-odds occupancy buffer (see occupancy_buffer.hpp). Each segmentation frame
+// contributes ground-plane observations via project_observations (waterline
+// contact → obstacle, water → free, occluded body → skipped); the buffer
+// remembers obstacles through gaps and forgets them over time. Phase 1+3 of
+// #19; still single-source (multi-camera fusion is phase 4).
 class SeaSurfaceLayer: public nav2_costmap_2d::Layer
 {
 public:
-  SeaSurfaceLayer()
-  {}
-
-  ~SeaSurfaceLayer()
-  {}
+  SeaSurfaceLayer() {}
+  ~SeaSurfaceLayer() {}
 
   void onInitialize() override
   {
     auto node = node_.lock();
 
     declareParameter("maximum_range", rclcpp::ParameterValue(maximum_range_));
-    node->get_parameter(name_+".maximum_range", maximum_range_);
+    node->get_parameter(name_ + ".maximum_range", maximum_range_);
 
+    // Log-odds occupancy parameters (runtime-tunable wiring is phase 6).
+    declareParameter("hit_log_odds", rclcpp::ParameterValue(params_.hit_log_odds));
+    node->get_parameter(name_ + ".hit_log_odds", params_.hit_log_odds);
+    declareParameter("miss_log_odds", rclcpp::ParameterValue(params_.miss_log_odds));
+    node->get_parameter(name_ + ".miss_log_odds", params_.miss_log_odds);
+    declareParameter("clamp", rclcpp::ParameterValue(params_.clamp));
+    node->get_parameter(name_ + ".clamp", params_.clamp);
+    declareParameter("lethal_threshold", rclcpp::ParameterValue(params_.lethal_threshold));
+    node->get_parameter(name_ + ".lethal_threshold", params_.lethal_threshold);
+    declareParameter("decay_half_life_s", rclcpp::ParameterValue(params_.decay_half_life_s));
+    node->get_parameter(name_ + ".decay_half_life_s", params_.decay_half_life_s);
+
+    std::string why;
+    if (!sea_surface_segmentation::OccupancyBuffer::validate(params_, why)) {
+      RCLCPP_WARN_STREAM(
+        logger_, "Invalid occupancy params (" << why << "); using defaults.");
+      params_ = sea_surface_segmentation::OccupancyParams{};
+    }
 
     declareParameter("segmentation_topic", rclcpp::ParameterValue("segmentation"));
     std::string segmentation_topic;
-    node->get_parameter(name_+".segmentation_topic", segmentation_topic);
+    node->get_parameter(name_ + ".segmentation_topic", segmentation_topic);
     declareParameter("camera_info_topic", rclcpp::ParameterValue("camera_info"));
     std::string camera_info_topic;
-    node->get_parameter(name_+".camera_info_topic", camera_info_topic);
+    node->get_parameter(name_ + ".camera_info_topic", camera_info_topic);
 
     global_frame_id_ = layered_costmap_->getGlobalFrameID();
 
-    // Initialize sizes before wiring subscribers. Under a multi-threaded
-    // executor with pre-existing publishers, a queued segmentation message
-    // could otherwise dispatch segmentsCallback before matchSize() runs,
-    // hitting the same count_x_-1 underflow that reset() guards against.
+    // Build the buffer before wiring subscribers so a queued segmentation
+    // message can't dispatch segmentsCallback against a null buffer_.
     matchSize();
 
     segments_subscriber_ = node->create_subscription<sensor_msgs::msg::Image>(
-      segmentation_topic,
-      rclcpp::SensorDataQoS(),
-      std::bind(&SeaSurfaceLayer::segmentsCallback, this, std::placeholders::_1)
-    );
+      segmentation_topic, rclcpp::SensorDataQoS(),
+      std::bind(&SeaSurfaceLayer::segmentsCallback, this, std::placeholders::_1));
 
     camera_info_subscriber_ = node->create_subscription<sensor_msgs::msg::CameraInfo>(
-      camera_info_topic,
-      rclcpp::SensorDataQoS(),
-      std::bind(&SeaSurfaceLayer::cameraInfoCallback, this, std::placeholders::_1)
-    );
+      camera_info_topic, rclcpp::SensorDataQoS(),
+      std::bind(&SeaSurfaceLayer::cameraInfoCallback, this, std::placeholders::_1));
   }
 
   void reset() override
   {
     std::lock_guard<std::mutex> lock(costmap_mutex_);
-    // Skip when matchSize() has not yet run: resetMapToValue would still touch
-    // cell (0,0) if count_x_/count_y_ aren't both zero, but the resizeMap call
-    // in matchSize() runs first under normal lifecycle and the guard makes the
-    // invariant explicit.
-    if (count_x_ == 0 || count_y_ == 0) {
-      return;
+    if (buffer_) {
+      buffer_->clear();
     }
-    // resetMapToValue uses exclusive (xn, yn) — matches nav2's [min, max) convention.
-    segments_costmap_.resetMapToValue(0, 0, count_x_, count_y_, nav2_costmap_2d::NO_INFORMATION);
   }
 
+  // The layer clears itself via decay + water-miss observations; nav2's
+  // clear-costmap behaviors don't need to (and shouldn't) wipe it.
   bool isClearable() override { return false; }
 
   void updateBounds(
-    double robot_x, double robot_y, double robot_yaw,
-    double* min_x, double* min_y,
-    double* max_x, double* max_y) override
+    double robot_x, double robot_y, double /*robot_yaw*/,
+    double * min_x, double * min_y, double * max_x, double * max_y) override
   {
-    // Expand the master bounds rather than overwrite — clobbering would drop
-    // bounds contributions from earlier layers in the chain (chart_layer, etc.).
+    // Expand (don't clobber) the master bounds so earlier layers' contributions survive.
     *min_x = std::min(*min_x, robot_x - maximum_range_);
     *min_y = std::min(*min_y, robot_y - maximum_range_);
     *max_x = std::max(*max_x, robot_x + maximum_range_);
     *max_y = std::max(*max_y, robot_y + maximum_range_);
 
     auto parent = layered_costmap_->getCostmap();
+    const bool geometry_changed =
+      parent->getSizeInCellsX() != count_x_ ||
+      parent->getSizeInCellsY() != count_y_ ||
+      parent->getResolution() != resolution_;
 
-    if(parent->getSizeInCellsX() != segments_costmap_.getSizeInCellsX() ||
-      parent->getSizeInCellsY() != segments_costmap_.getSizeInCellsY() ||
-      parent->getOriginX() != segments_costmap_.getOriginX() ||
-      parent->getOriginY() != segments_costmap_.getOriginY() ||
-      parent->getResolution() != segments_costmap_.getResolution()
-    )
-    {
-      matchSize();
+    if (geometry_changed) {
+      matchSize();  // recreate the buffer at the new size/resolution (locks internally)
+    } else {
+      // Rolling-window origin shift: roll the buffer to follow the parent so
+      // accumulated evidence stays at its world location (grid_map::move()).
+      std::lock_guard<std::mutex> lock(costmap_mutex_);
+      if (buffer_) {
+        buffer_->move(parentCenter(parent));
+      }
+    }
+
+    // Decay accumulated evidence toward the prior once per cycle.
+    if (auto node = node_.lock()) {
+      std::lock_guard<std::mutex> lock(costmap_mutex_);
+      if (buffer_) {
+        buffer_->decay(node->now().seconds());
+      }
     }
   }
 
   void updateCosts(
-    nav2_costmap_2d::Costmap2D& master_grid,
-    int min_i, int min_j, int max_i, int max_j)  override
+    nav2_costmap_2d::Costmap2D & master_grid,
+    int min_i, int min_j, int max_i, int max_j) override
   {
     std::lock_guard<std::mutex> lock(costmap_mutex_);
-    apply_segments_to_master(segments_costmap_, master_grid, min_i, min_j, max_i, max_j);
+    if (!buffer_) {
+      return;
+    }
+    // Stamp LETHAL into the master where the buffer has crossed the threshold.
+    // Leave everything else untouched (other layers + inflation own free/unknown).
+    for (int i = min_i; i < max_i; ++i) {
+      for (int j = min_j; j < max_j; ++j) {
+        double wx, wy;
+        master_grid.mapToWorld(static_cast<unsigned int>(i), static_cast<unsigned int>(j), wx, wy);
+        if (buffer_->isLethal(grid_map::Position(wx, wy))) {
+          master_grid.setCost(
+            static_cast<unsigned int>(i), static_cast<unsigned int>(j),
+            nav2_costmap_2d::LETHAL_OBSTACLE);
+        }
+      }
+    }
   }
 
   void matchSize() override
   {
-    RCLCPP_INFO_STREAM(logger_, "Matching size of SeaSurfaceLayer to parent costmap");
     auto parent = layered_costmap_->getCostmap();
-
-    // Lock around resizeMap — it deletes and reallocates the costmap buffer,
-    // racing with segmentsCallback's setCost loop on rolling-window costmaps
-    // where updateBounds triggers matchSize on every origin shift (#6).
     std::lock_guard<std::mutex> lock(costmap_mutex_);
 
     origin_x_ = parent->getOriginX();
@@ -126,139 +159,99 @@ public:
     count_x_ = parent->getSizeInCellsX();
     count_y_ = parent->getSizeInCellsY();
 
-    segments_costmap_.resizeMap(count_x_, count_y_, resolution_, origin_x_, origin_y_);
+    const double size_x = count_x_ * resolution_;
+    const double size_y = count_y_ * resolution_;
+    buffer_ = std::make_unique<sea_surface_segmentation::OccupancyBuffer>(
+      size_x, size_y, resolution_, parentCenter(parent), params_);
+    RCLCPP_INFO_STREAM(
+      logger_, "SeaSurfaceLayer occupancy buffer sized to " << count_x_ << "x" << count_y_);
   }
 
 private:
-  std::string global_frame_id_;
-
-  double update_timeout_ = 0.5;
+  // World position of the parent costmap's center (grid_map is positioned by
+  // its center; nav2 Costmap2D by its lower-left origin).
+  static grid_map::Position parentCenter(nav2_costmap_2d::Costmap2D * parent)
+  {
+    return grid_map::Position(
+      parent->getOriginX() + parent->getSizeInCellsX() * parent->getResolution() / 2.0,
+      parent->getOriginY() + parent->getSizeInCellsY() * parent->getResolution() / 2.0);
+  }
 
   void segmentsCallback(const sensor_msgs::msg::Image::SharedPtr segments_msg)
   {
-    if(camera_model_)
-    {
+    if (!camera_model_) {
+      return;
+    }
+    try {
+      // Camera pose in the world (costmap global) frame: translation = optical
+      // center, rotation = camera-optical → world.
+      const auto tf = tf_->lookupTransform(
+        global_frame_id_, segments_msg->header.frame_id, segments_msg->header.stamp,
+        std::chrono::seconds(1));
+      const auto image = cv_bridge::toCvShare(segments_msg, "rgb8");
 
-      try
-      {
-      
-        auto transform = tf_->lookupTransform(
-          segments_msg->header.frame_id, global_frame_id_, segments_msg->header.stamp, std::chrono::seconds(1));
+      const auto & t = tf.transform.translation;
+      const auto & q = tf.transform.rotation;
+      const cv::Vec3d camera_origin(t.x, t.y, t.z);
+      const cv::Matx33d rotation_cam_to_world =
+        sea_surface_segmentation::rotation_matrix_from_quaternion(q.x, q.y, q.z, q.w);
 
-        auto image = cv_bridge::toCvShare(segments_msg, "rgb8");
+      // Water surface is z=0 in the tide-tracked global frame; the boat floats,
+      // so this holds at any tide (see #19 / #10 H discussion).
+      const auto observations = sea_surface_segmentation::project_observations(
+        image->image, *camera_model_, camera_origin, rotation_cam_to_world, maximum_range_, 0.0);
 
-
-        std::lock_guard<std::mutex> lock(costmap_mutex_);
-
-        // Defensive guard: matchSize() runs before subscribers are created,
-        // but keep the invariant local so future reorderings can't reintroduce
-        // a zero-size access.
-        if (count_x_ == 0 || count_y_ == 0) {
-          return;
-        }
-        // resetMapToValue uses exclusive (xn, yn) — matches nav2's [min, max) convention.
-        segments_costmap_.resetMapToValue(0, 0, count_x_, count_y_, nav2_costmap_2d::NO_INFORMATION);
-
-        for(unsigned int i = 0; i < count_x_; i++)
-        {
-          for(unsigned int j = 0; j < count_y_; j++)
-          {
-            double map_x, map_y;
-            segments_costmap_.mapToWorld(i, j, map_x, map_y);
-            geometry_msgs::msg::PointStamped point_in_map;
-            point_in_map.point.x = map_x;
-            point_in_map.point.y = map_y;
-            point_in_map.point.z = 0.0;
-            point_in_map.header.frame_id = global_frame_id_;
-            point_in_map.header.stamp = segments_msg->header.stamp;
-            geometry_msgs::msg::PointStamped point_in_camera;
-            tf2::doTransform(point_in_map, point_in_camera, transform);
-
-            if(point_in_camera.point.z < 0.0)
-            {
-              continue; // Skip points behind the camera
-            }
-
-            auto ray_length = sqrt(point_in_camera.point.x * point_in_camera.point.x +
-                                      point_in_camera.point.y * point_in_camera.point.y +
-                                      point_in_camera.point.z * point_in_camera.point.z);
-
-            if(ray_length > maximum_range_)
-            {
-              continue;
-            }
-
-            auto pixel = camera_model_->project3dToPixel(cv::Point3d(
-              point_in_camera.point.x, point_in_camera.point.y, point_in_camera.point.z));
-            
-            if(pixel.x >= 0 && pixel.x < static_cast<int>(image->image.cols) &&
-               pixel.y >= 0 && pixel.y < static_cast<int>(image->image.rows))
-            {
-              auto pixel_value = image->image.at<cv::Vec3b>(pixel);
-              // Segmentation channel convention: dominant R marks non-water
-              // (lethal obstacle); dominant G/B marks water (free space).
-              if(sea_surface_segmentation::is_obstacle_pixel(pixel_value))
-              {
-                // Only the waterline contact is a trustworthy z=0 footprint. An
-                // obstacle's above-water body pixels back-project far beyond the
-                // real obstacle, smearing a false radial "shadow" of lethal
-                // cells out toward maximum_range. Mark only the contact lethal;
-                // leave the rest at NO_INFORMATION (occluded/unknown — the value
-                // reset at the start of this callback).
-                if(sea_surface_segmentation::is_waterline_contact_pixel(
-                     image->image, static_cast<int>(pixel.y), static_cast<int>(pixel.x)))
-                {
-                  segments_costmap_.setCost(i, j, nav2_costmap_2d::LETHAL_OBSTACLE);
-                }
-              }
-              else
-              {
-                segments_costmap_.setCost(i, j, nav2_costmap_2d::FREE_SPACE);
-              }
-            }
-          }
+      std::lock_guard<std::mutex> lock(costmap_mutex_);
+      if (!buffer_) {
+        return;
+      }
+      for (const auto & obs : observations) {
+        const grid_map::Position p(obs.x, obs.y);
+        if (obs.obstacle) {
+          buffer_->hit(p);
+        } else {
+          buffer_->miss(p);
         }
       }
-      catch(const std::exception& e)
-      {
-        RCLCPP_WARN_STREAM(logger_, e.what());
-      }
+    } catch (const std::exception & e) {
+      RCLCPP_WARN_STREAM(logger_, e.what());
     }
   }
 
   void cameraInfoCallback(const sensor_msgs::msg::CameraInfo::SharedPtr camera_info_msg)
   {
+    std::lock_guard<std::mutex> lock(costmap_mutex_);
     camera_info_ = *camera_info_msg;
-    if(!camera_model_) {
+    if (!camera_model_) {
       camera_model_ = std::make_shared<image_geometry::PinholeCameraModel>();
     }
     camera_model_->fromCameraInfo(camera_info_);
   }
 
+  std::string global_frame_id_;
 
+  // Parent-costmap geometry tracking (to detect true size/resolution changes
+  // vs rolling-origin shifts).
   double origin_x_ = 0.0;
   double origin_y_ = 0.0;
   double resolution_ = 1.0;
   unsigned int count_x_ = 0;
   unsigned int count_y_ = 0;
 
-  nav2_costmap_2d::Costmap2D segments_costmap_;
-
   double maximum_range_ = 100.0;
-
+  sea_surface_segmentation::OccupancyParams params_;
+  std::unique_ptr<sea_surface_segmentation::OccupancyBuffer> buffer_;
 
   rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr segments_subscriber_;
   rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_subscriber_;
-
 
   sensor_msgs::msg::CameraInfo camera_info_;
   std::shared_ptr<image_geometry::PinholeCameraModel> camera_model_;
 
   std::mutex costmap_mutex_;
-
 };
 
-} // namespace sea_surface_layer
+}  // namespace sea_surface_layer
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(sea_surface_layer::SeaSurfaceLayer, nav2_costmap_2d::Layer)

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -9,6 +9,7 @@
 
 #include "cv_bridge/cv_bridge.hpp"
 #include "image_geometry/pinhole_camera_model.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
 #include "rclcpp/parameter.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
@@ -162,6 +163,21 @@ public:
     // poison the buffer interpretation.
     param_callback_handle_ = node->add_on_set_parameters_callback(
       std::bind(&SeaSurfaceLayer::onParametersSet, this, std::placeholders::_1));
+
+    // Optional publish-and-relay: when `published_topic` is non-empty, the
+    // layer republishes its lethal cells as a nav_msgs/OccupancyGrid on that
+    // topic so the companion `SeaSurfaceRelayLayer` (in global_costmap) can
+    // stamp them into the global costmap before inflation. Mirrors the
+    // s57_grids / s57_layer producer/consumer pattern; the projection still
+    // runs only once. Defaults to off (empty topic = no publisher).
+    declareParameter("published_topic", rclcpp::ParameterValue(std::string{}));
+    node->get_parameter(name_ + ".published_topic", published_topic_);
+    if (!published_topic_.empty()) {
+      lethal_publisher_ = node->create_publisher<nav_msgs::msg::OccupancyGrid>(
+        published_topic_, rclcpp::QoS(1).transient_local());
+      RCLCPP_INFO_STREAM(
+        logger_, "SeaSurfaceLayer publishing lethal grid on '" << published_topic_ << "'");
+    }
   }
 
   void reset() override
@@ -217,6 +233,11 @@ public:
         buffer_->decay(node->now().seconds());
       }
     }
+
+    // Republish the lethal cells for any downstream consumer (e.g. the
+    // SeaSurfaceRelayLayer in global_costmap). No-op when no publisher was
+    // wired in onInitialize (published_topic was empty).
+    publishLethalGrid();
   }
 
   void updateCosts(
@@ -392,6 +413,62 @@ private:
     src.camera_model = model;
   }
 
+  // Publish the lethal-cell mask as a nav_msgs/OccupancyGrid so a downstream
+  // `SeaSurfaceRelayLayer` (or any consumer) can stamp the same lethal cells
+  // into a different costmap without rerunning the segmentation projection.
+  // Cells at or above the lethal threshold publish as 100; everything else
+  // (unobserved or sub-threshold) publishes as -1 ("no opinion") so the
+  // consumer never inadvertently clears another layer's marks. Header frame
+  // is the costmap's global frame (e.g. `map_tide`).
+  void publishLethalGrid()
+  {
+    if (!lethal_publisher_) {
+      return;
+    }
+    auto node = node_.lock();
+    if (!node) {
+      return;
+    }
+    nav_msgs::msg::OccupancyGrid msg;
+    msg.header.stamp = node->now();
+    msg.header.frame_id = global_frame_id_;
+
+    {
+      std::lock_guard<std::mutex> lock(costmap_mutex_);
+      if (!buffer_) {
+        return;
+      }
+      const auto & map = buffer_->map();
+      const auto size = map.getSize();
+      const auto center = map.getPosition();
+      msg.info.resolution = static_cast<float>(map.getResolution());
+      msg.info.width = static_cast<uint32_t>(size(0));
+      msg.info.height = static_cast<uint32_t>(size(1));
+      // grid_map is positioned by its center; OccupancyGrid origin is the
+      // lower-left corner of cell (0, 0).
+      msg.info.origin.position.x = center(0) - 0.5 * size(0) * map.getResolution();
+      msg.info.origin.position.y = center(1) - 0.5 * size(1) * map.getResolution();
+      msg.info.origin.position.z = 0.0;
+      msg.info.origin.orientation.w = 1.0;
+      msg.data.assign(static_cast<size_t>(size(0)) * size(1), -1);
+
+      // Walk OccupancyGrid cells in row-major order; for each cell's world
+      // position, query the buffer's lethal test. Avoids dancing through
+      // grid_map's column-major / circular-buffer index layout.
+      for (uint32_t y = 0; y < msg.info.height; ++y) {
+        for (uint32_t x = 0; x < msg.info.width; ++x) {
+          const double wx = msg.info.origin.position.x + (x + 0.5) * msg.info.resolution;
+          const double wy = msg.info.origin.position.y + (y + 0.5) * msg.info.resolution;
+          if (buffer_->isLethal(grid_map::Position(wx, wy))) {
+            msg.data[static_cast<size_t>(y) * msg.info.width + x] = 100;
+          }
+        }
+      }
+    }
+
+    lethal_publisher_->publish(msg);
+  }
+
   // Validate-then-apply param updates. Runs on the parameter service thread.
   // Builds a candidate copy of the live-tunable state from `params` (each named
   // entry overrides the candidate field), validates the candidate (NaN /
@@ -472,6 +549,14 @@ private:
   std::vector<std::unique_ptr<Source>> sources_;
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
+
+  // Optional publish-and-relay output (phase 8 / new offline-review scope):
+  // when `published_topic_` is non-empty, the layer republishes its lethal
+  // cells on it so a downstream `SeaSurfaceRelayLayer` can stamp them into
+  // a different costmap (e.g. global_costmap, before inflation) without
+  // running the segmentation projection a second time.
+  std::string published_topic_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr lethal_publisher_;
 
   std::mutex costmap_mutex_;
 };

--- a/sea_surface_segmentation/src/sea_surface_relay_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_relay_layer.cpp
@@ -1,0 +1,181 @@
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp/subscription.hpp"
+#include "nav2_costmap_2d/cost_values.hpp"
+#include "nav2_costmap_2d/layer.hpp"
+#include "nav2_costmap_2d/layered_costmap.hpp"
+
+namespace sea_surface_layer
+{
+
+// Thin costmap layer that stamps LETHAL where a peer SeaSurfaceLayer (running
+// in a different costmap, typically local) has published its lethal cells.
+//
+// Why a relay instead of a second SeaSurfaceLayer in the global costmap: the
+// segmentation projection is the expensive step (N cameras × image-size
+// iterations per frame); running it twice (once per costmap) would double the
+// cost for no information gain since both costmaps end up with the same lethal
+// cells. The producer publishes once; this consumer copies. Mirrors the
+// s57_grids / s57_layer producer/consumer pattern.
+//
+// Only the LETHAL cells are stamped. Sub-threshold and unobserved cells (-1 in
+// the published OccupancyGrid) are left untouched so the relay never clears
+// another layer's marks — the global costmap's chart/inflation contributions
+// stay authoritative; sea-surface only ADDS.
+class SeaSurfaceRelayLayer: public nav2_costmap_2d::Layer
+{
+public:
+  SeaSurfaceRelayLayer() {}
+  ~SeaSurfaceRelayLayer() {}
+
+  void onInitialize() override
+  {
+    auto node = node_.lock();
+    declareParameter(
+      "topic", rclcpp::ParameterValue(std::string("sea_surface/lethal_grid")));
+    node->get_parameter(name_ + ".topic", topic_);
+
+    global_frame_id_ = layered_costmap_->getGlobalFrameID();
+
+    // Transient-local QoS matches the producer's publisher so a late-joining
+    // global costmap still gets the most recent map (the producer publishes on
+    // each updateBounds cycle ≈ 5–20 Hz; we cache the latest).
+    grid_sub_ = node->create_subscription<nav_msgs::msg::OccupancyGrid>(
+      topic_, rclcpp::QoS(1).transient_local(),
+      std::bind(&SeaSurfaceRelayLayer::gridCallback, this, std::placeholders::_1));
+
+    RCLCPP_INFO_STREAM(
+      logger_,
+      "SeaSurfaceRelayLayer subscribing to '" << topic_ << "' (expects frame '"
+        << global_frame_id_ << "')");
+  }
+
+  void reset() override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    latest_.reset();
+  }
+
+  // The producer owns clearing via decay; the relay never clears.
+  bool isClearable() override { return false; }
+
+  void updateBounds(
+    double /*robot_x*/, double /*robot_y*/, double /*robot_yaw*/,
+    double * min_x, double * min_y, double * max_x, double * max_y) override
+  {
+    nav_msgs::msg::OccupancyGrid::SharedPtr msg;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      msg = latest_;
+    }
+    if (!msg) {
+      return;
+    }
+    // Expand the master bounds to cover the published grid so the master's
+    // updateCosts call reaches every cell the producer can mark — otherwise
+    // an over-tight master bound would silently drop lethal cells from outside
+    // it. The min/max merge is non-destructive: earlier layers' contributions
+    // survive.
+    const double ox = msg->info.origin.position.x;
+    const double oy = msg->info.origin.position.y;
+    const double sx = msg->info.width * msg->info.resolution;
+    const double sy = msg->info.height * msg->info.resolution;
+    *min_x = std::min(*min_x, ox);
+    *min_y = std::min(*min_y, oy);
+    *max_x = std::max(*max_x, ox + sx);
+    *max_y = std::max(*max_y, oy + sy);
+  }
+
+  void updateCosts(
+    nav2_costmap_2d::Costmap2D & master_grid,
+    int min_i, int min_j, int max_i, int max_j) override
+  {
+    nav_msgs::msg::OccupancyGrid::SharedPtr msg;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      msg = latest_;
+    }
+    if (!msg) {
+      return;
+    }
+    if (msg->info.resolution <= 0.0 || msg->info.width == 0 || msg->info.height == 0) {
+      return;
+    }
+
+    const double ox = msg->info.origin.position.x;
+    const double oy = msg->info.origin.position.y;
+    const double inv_res = 1.0 / msg->info.resolution;
+    const uint32_t mw = msg->info.width;
+    const uint32_t mh = msg->info.height;
+
+    // Walk the master cells in the requested bounds; for each, look up the
+    // corresponding cell in the published grid. Looking the producer's cell up
+    // by world position rather than direct index avoids requiring identical
+    // origin / resolution between the two costmaps — the global costmap can
+    // have its own pose / resolution and still pick up the producer's lethal
+    // cells correctly.
+    for (int i = min_i; i < max_i; ++i) {
+      for (int j = min_j; j < max_j; ++j) {
+        double wx, wy;
+        master_grid.mapToWorld(
+          static_cast<unsigned int>(i), static_cast<unsigned int>(j), wx, wy);
+        const double mx = (wx - ox) * inv_res;
+        const double my = (wy - oy) * inv_res;
+        if (mx < 0.0 || my < 0.0) {
+          continue;
+        }
+        const auto x = static_cast<uint32_t>(mx);
+        const auto y = static_cast<uint32_t>(my);
+        if (x >= mw || y >= mh) {
+          continue;
+        }
+        if (msg->data[static_cast<size_t>(y) * mw + x] >= 100) {
+          master_grid.setCost(
+            static_cast<unsigned int>(i), static_cast<unsigned int>(j),
+            nav2_costmap_2d::LETHAL_OBSTACLE);
+        }
+      }
+    }
+    // Considered current once a grid has been received and consumed.
+    current_ = true;
+  }
+
+  void matchSize() override {}  // no internal buffer to resize
+
+private:
+  void gridCallback(nav_msgs::msg::OccupancyGrid::SharedPtr msg)
+  {
+    if (msg->header.frame_id != global_frame_id_) {
+      if (auto node = node_.lock()) {
+        auto clock = node->get_clock();
+        RCLCPP_WARN_THROTTLE(
+          logger_, *clock, 5000,
+          "SeaSurfaceRelayLayer received grid in frame '%s' but expects '%s'; "
+          "stamping LETHAL cells at the wrong world positions is a safety risk — "
+          "dropping the message",
+          msg->header.frame_id.c_str(), global_frame_id_.c_str());
+      }
+      return;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    latest_ = msg;
+  }
+
+  std::string topic_;
+  std::string global_frame_id_;
+  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr grid_sub_;
+  nav_msgs::msg::OccupancyGrid::SharedPtr latest_;
+  std::mutex mutex_;
+};
+
+}  // namespace sea_surface_layer
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(sea_surface_layer::SeaSurfaceRelayLayer, nav2_costmap_2d::Layer)

--- a/sea_surface_segmentation/src/segments_projection.hpp
+++ b/sea_surface_segmentation/src/segments_projection.hpp
@@ -356,7 +356,8 @@ inline std::vector<OccupancyObservation> project_observations_inverse(
   const cv::Matx33d & rotation_cam_to_target,
   double max_range,
   double cx, double cy, double res, double half_extent,
-  double plane_z = 0.0)
+  double plane_z = 0.0,
+  double min_grazing_angle_deg = 0.0)
 {
   // Lowest (nearest) waterline contact per column — same primitive as forward.
   std::vector<int> contact_row(mask_rgb8.cols, -1);
@@ -369,6 +370,15 @@ inline std::vector<OccupancyObservation> project_observations_inverse(
     }
   }
 
+  // Grazing-angle cutoff: reject rays where |dz| / |d| < sin(min_grazing) —
+  // i.e. rays that hit the water plane at less than the configured angle from
+  // horizontal. Squared form avoids the per-cell sqrt: |dz|^2 >= s^2 * |d|^2
+  // (both sides non-negative, squaring preserves the inequality). A camera at
+  // height h enforces max horizontal range ≈ h / tan(min_grazing): at h=1.5 m
+  // and 5°, that's ~17 m; at 2°, ~43 m. Default 0° = no filter (back-compat).
+  const double min_grazing_sin = std::sin(min_grazing_angle_deg * M_PI / 180.0);
+  const double min_grazing_sin_sq = min_grazing_sin * min_grazing_sin;
+
   const cv::Matx33d rotation_target_to_cam = rotation_cam_to_target.t();
   std::vector<OccupancyObservation> observations;
   const int n = static_cast<int>(std::lround(2.0 * half_extent / res));
@@ -377,7 +387,11 @@ inline std::vector<OccupancyObservation> project_observations_inverse(
       const double wx = cx + (ix - n / 2) * res;
       const double wy = cy + (iy - n / 2) * res;
       const cv::Vec3d d(wx - camera_origin[0], wy - camera_origin[1], plane_z - camera_origin[2]);
-      if (std::sqrt(d.dot(d)) > max_range) { continue; }  // beyond sensor range
+      const double range_sq = d.dot(d);
+      if (range_sq > max_range * max_range) { continue; }  // beyond sensor range
+      if (min_grazing_sin > 0.0 && d[2] * d[2] < min_grazing_sin_sq * range_sq) {
+        continue;  // ray strikes water plane too shallowly — high ground-error per pitch arc-sec
+      }
       const cv::Vec3d pc = rotation_target_to_cam * d;    // cell in camera optical frame
       if (pc[2] <= 0.0) { continue; }                     // behind the camera (+z forward)
       const cv::Point2d uv = camera_model.project3dToPixel(cv::Point3d(pc[0], pc[1], pc[2]));

--- a/sea_surface_segmentation/src/segments_projection.hpp
+++ b/sea_surface_segmentation/src/segments_projection.hpp
@@ -46,6 +46,33 @@ inline bool is_obstacle_pixel(const cv::Vec3b & pixel)
   return pixel[0] > pixel[1] && pixel[0] > pixel[2];
 }
 
+// True if an obstacle pixel is a "waterline contact" — the point where an
+// obstacle meets the water surface — rather than part of the obstacle's body
+// sticking up out of the water.
+//
+// An obstacle pixel is a contact iff the pixel directly below it is water
+// (non-obstacle), or it sits on the bottom image row (nothing below to
+// disqualify it — the nearest possible return for that bearing). Pixels with
+// more obstacle below them are the object's body.
+//
+// Why it matters: the costmap layer back-projects every obstacle pixel onto
+// the z=0 water plane. That assumption holds only at the waterline; an
+// above-water body pixel back-projects far beyond the real obstacle, smearing
+// a false radial "shadow" of lethal cells out toward maximum_range. Only the
+// contact is a trustworthy footprint; the region the body occludes should be
+// left unknown (NO_INFORMATION), not marked lethal. Callers use this to mark
+// the contact lethal and skip the rest.
+inline bool is_waterline_contact_pixel(const cv::Mat & mask, int row, int col)
+{
+  if (!is_obstacle_pixel(mask.at<cv::Vec3b>(row, col))) {
+    return false;
+  }
+  if (row + 1 >= mask.rows) {
+    return true;  // bottom image row: nearest possible return for this bearing
+  }
+  return !is_obstacle_pixel(mask.at<cv::Vec3b>(row + 1, col));
+}
+
 // Convert a quaternion (x, y, z, w) into the 3×3 rotation matrix that maps
 // a direction in the camera optical frame to the target frame — i.e. the
 // `rotation_cam_to_target` argument of `project_obstacle_pixels`. The input

--- a/sea_surface_segmentation/src/segments_projection.hpp
+++ b/sea_surface_segmentation/src/segments_projection.hpp
@@ -239,4 +239,94 @@ inline std::vector<ProjectedPoint> project_obstacle_pixels(
   return points;
 }
 
+// A ground-plane occupancy observation produced from one segmentation pixel:
+// a world (x, y) point on the plane `z = plane_z`, and whether it is an
+// obstacle (a waterline contact) or free water.
+struct OccupancyObservation
+{
+  double x;
+  double y;
+  bool obstacle;
+};
+
+// Back-project a segmentation mask into ground-plane occupancy observations for
+// the rolling log-odds buffer. This is the shared per-frame logic used by BOTH
+// the costmap layer and the offline bag→costmap utility, so they produce
+// identical results.
+//
+// Per image COLUMN, the lowest obstacle pixel with water directly below is the
+// waterline contact (`is_waterline_contact_pixel`) → one **obstacle**
+// observation at its ground intersection. Obstacle pixels above the contact are
+// the object's body: occluded, so they are skipped (not projected — this is the
+// shadow fix). Water pixels → **free** observations (the camera positively sees
+// water there). Rays that miss the plane (parallel / point away) or land beyond
+// `max_range` are dropped (same geometry as `project_obstacle_pixels`).
+//
+// Pure logic: no ROS/TF. The caller supplies the camera pose in the target
+// (world) frame via `camera_origin` + `rotation_cam_to_target` and applies each
+// observation to the buffer (obstacle → hit, free → miss).
+inline std::vector<OccupancyObservation> project_observations(
+  const cv::Mat & mask_rgb8,
+  const image_geometry::PinholeCameraModel & camera_model,
+  const cv::Vec3d & camera_origin,
+  const cv::Matx33d & rotation_cam_to_target,
+  double max_range,
+  double plane_z = 0.0)
+{
+  std::vector<OccupancyObservation> observations;
+
+  for (int col = 0; col < mask_rgb8.cols; ++col) {
+    // Lowest (nearest) waterline contact in this column, scanning up from the
+    // bottom. -1 if the column has no obstacle-over-water transition.
+    int contact_row = -1;
+    for (int row = mask_rgb8.rows - 1; row >= 0; --row) {
+      if (is_waterline_contact_pixel(mask_rgb8, row, col)) {
+        contact_row = row;
+        break;
+      }
+    }
+
+    for (int row = 0; row < mask_rgb8.rows; ++row) {
+      const cv::Vec3b pixel_value = mask_rgb8.at<cv::Vec3b>(row, col);
+      bool obstacle_obs;
+      if (is_obstacle_pixel(pixel_value)) {
+        if (row != contact_row) {
+          continue;  // occluded body above the waterline contact — skip
+        }
+        obstacle_obs = true;  // the waterline contact itself
+      } else {
+        obstacle_obs = false;  // water → free observation
+      }
+
+      // Ray → plane intersection in the target frame (cf. project_obstacle_pixels).
+      const cv::Point3d ray_cam = camera_model.projectPixelTo3dRay(cv::Point2d(col, row));
+      const cv::Vec3d ray_target = rotation_cam_to_target *
+        cv::Vec3d(ray_cam.x, ray_cam.y, ray_cam.z);
+      if (!std::isfinite(ray_target[0]) || !std::isfinite(ray_target[1]) ||
+        !std::isfinite(ray_target[2]) || ray_target[2] == 0.0)
+      {
+        continue;
+      }
+      const double u = (plane_z - camera_origin[2]) / ray_target[2];
+      if (!std::isfinite(u) || u <= 0.0) {
+        continue;  // ray parallel to / behind the plane
+      }
+      const double wx = camera_origin[0] + u * ray_target[0];
+      const double wy = camera_origin[1] + u * ray_target[1];
+      if (!std::isfinite(wx) || !std::isfinite(wy)) {
+        continue;
+      }
+      const double dx = wx - camera_origin[0];
+      const double dy = wy - camera_origin[1];
+      const double dz = plane_z - camera_origin[2];
+      if (std::sqrt(dx * dx + dy * dy + dz * dz) > max_range) {
+        continue;  // beyond sensor range
+      }
+      observations.push_back({wx, wy, obstacle_obs});
+    }
+  }
+
+  return observations;
+}
+
 }  // namespace sea_surface_segmentation

--- a/sea_surface_segmentation/src/segments_projection.hpp
+++ b/sea_surface_segmentation/src/segments_projection.hpp
@@ -64,6 +64,9 @@ inline bool is_obstacle_pixel(const cv::Vec3b & pixel)
 // the contact lethal and skip the rest.
 inline bool is_waterline_contact_pixel(const cv::Mat & mask, int row, int col)
 {
+  if (row < 0 || col < 0 || row >= mask.rows || col >= mask.cols) {
+    return false;  // defensive: out-of-range never a contact
+  }
   if (!is_obstacle_pixel(mask.at<cv::Vec3b>(row, col))) {
     return false;
   }

--- a/sea_surface_segmentation/src/segments_projection.hpp
+++ b/sea_surface_segmentation/src/segments_projection.hpp
@@ -381,15 +381,16 @@ inline std::vector<OccupancyObservation> project_observations_inverse(
       const cv::Vec3d pc = rotation_target_to_cam * d;    // cell in camera optical frame
       if (pc[2] <= 0.0) { continue; }                     // behind the camera (+z forward)
       const cv::Point2d uv = camera_model.project3dToPixel(cv::Point3d(pc[0], pc[1], pc[2]));
+      if (!std::isfinite(uv.x) || !std::isfinite(uv.y)) { continue; }
       const int u = static_cast<int>(std::lround(uv.x));
       const int v = static_cast<int>(std::lround(uv.y));
       if (u < 0 || u >= mask_rgb8.cols || v < 0 || v >= mask_rgb8.rows) { continue; }
       const cv::Vec3b px = mask_rgb8.at<cv::Vec3b>(v, u);
       if (is_obstacle_pixel(px)) {
-        if (contact_row[u] >= 0 && v >= contact_row[u]) {
+        if (v == contact_row[u]) {
           observations.push_back({wx, wy, true});         // waterline contact → hit
         }
-        // else: above the contact = occluded body → leave unobserved
+        // else: above (or below an unselected) contact = body → leave unobserved
       } else if (px[1] > px[0] && px[1] > px[2]) {        // green-dominant = water
         observations.push_back({wx, wy, false});          // positively observed water → miss
       }

--- a/sea_surface_segmentation/src/segments_projection.hpp
+++ b/sea_surface_segmentation/src/segments_projection.hpp
@@ -329,4 +329,74 @@ inline std::vector<OccupancyObservation> project_observations(
   return observations;
 }
 
+// INVERSE (cell→pixel) ground-plane projection — sibling to `project_observations`.
+// Instead of iterating image pixels and back-projecting each to one world cell, this
+// iterates world cells in an axis-aligned window centred on (cx, cy) and asks
+// "which pixel covers this cell?". One large/distant pixel fills EVERY cell its
+// ray covers (no gaps), and iteration is naturally range-bounded to the window
+// (a near-horizon pixel can't smear past the window edge).
+//
+// Pixel classification (rgb8 channels: R=obstacle, G=water, B=sky):
+//   - obstacle pixel that is the column's waterline contact → hit
+//   - obstacle pixel above the contact (occluded body) → skip (unobserved)
+//   - water pixel (green-dominant) → miss (positively observed free)
+//   - sky pixel (blue-dominant) or ambiguous → skip (a ground cell on z=0 sampling
+//     a sky pixel is a geometric inconsistency; clearing on it would erase
+//     legitimate hits from other frames / cameras)
+//
+// Pure logic: no ROS/TF. Caller supplies the camera pose in the target (world)
+// frame via `camera_origin` + `rotation_cam_to_target`. `(cx, cy)` is the iteration
+// centre in the target frame (the layer passes the camera origin's XY; the offline
+// utility passes the boat-XY for boat-centred visualisation). `half_extent` is the
+// iteration half-width of the square AABB; `res` is the cell pitch.
+inline std::vector<OccupancyObservation> project_observations_inverse(
+  const cv::Mat & mask_rgb8,
+  const image_geometry::PinholeCameraModel & camera_model,
+  const cv::Vec3d & camera_origin,
+  const cv::Matx33d & rotation_cam_to_target,
+  double max_range,
+  double cx, double cy, double res, double half_extent,
+  double plane_z = 0.0)
+{
+  // Lowest (nearest) waterline contact per column — same primitive as forward.
+  std::vector<int> contact_row(mask_rgb8.cols, -1);
+  for (int col = 0; col < mask_rgb8.cols; ++col) {
+    for (int row = mask_rgb8.rows - 1; row >= 0; --row) {
+      if (is_waterline_contact_pixel(mask_rgb8, row, col)) {
+        contact_row[col] = row;
+        break;
+      }
+    }
+  }
+
+  const cv::Matx33d rotation_target_to_cam = rotation_cam_to_target.t();
+  std::vector<OccupancyObservation> observations;
+  const int n = static_cast<int>(std::lround(2.0 * half_extent / res));
+  for (int iy = 0; iy < n; ++iy) {
+    for (int ix = 0; ix < n; ++ix) {
+      const double wx = cx + (ix - n / 2) * res;
+      const double wy = cy + (iy - n / 2) * res;
+      const cv::Vec3d d(wx - camera_origin[0], wy - camera_origin[1], plane_z - camera_origin[2]);
+      if (std::sqrt(d.dot(d)) > max_range) { continue; }  // beyond sensor range
+      const cv::Vec3d pc = rotation_target_to_cam * d;    // cell in camera optical frame
+      if (pc[2] <= 0.0) { continue; }                     // behind the camera (+z forward)
+      const cv::Point2d uv = camera_model.project3dToPixel(cv::Point3d(pc[0], pc[1], pc[2]));
+      const int u = static_cast<int>(std::lround(uv.x));
+      const int v = static_cast<int>(std::lround(uv.y));
+      if (u < 0 || u >= mask_rgb8.cols || v < 0 || v >= mask_rgb8.rows) { continue; }
+      const cv::Vec3b px = mask_rgb8.at<cv::Vec3b>(v, u);
+      if (is_obstacle_pixel(px)) {
+        if (contact_row[u] >= 0 && v >= contact_row[u]) {
+          observations.push_back({wx, wy, true});         // waterline contact → hit
+        }
+        // else: above the contact = occluded body → leave unobserved
+      } else if (px[1] > px[0] && px[1] > px[2]) {        // green-dominant = water
+        observations.push_back({wx, wy, false});          // positively observed water → miss
+      }
+      // else: sky (blue-dominant) or ambiguous → skip (no observation)
+    }
+  }
+  return observations;
+}
+
 }  // namespace sea_surface_segmentation

--- a/sea_surface_segmentation/test/test_layer_plugin_loading.cpp
+++ b/sea_surface_segmentation/test/test_layer_plugin_loading.cpp
@@ -1,0 +1,98 @@
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "nav2_costmap_2d/layer.hpp"
+#include "nav2_costmap_2d/layered_costmap.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "pluginlib/class_loader.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2_ros/buffer.h"
+
+// Verify the SeaSurfaceLayer + SeaSurfaceRelayLayer plugins load via pluginlib
+// from the package's costmap_plugins.xml descriptor — catches plugin
+// registration issues (wrong class name in the export macro, missing
+// `<class>` entry, broken shared library).
+TEST(SeaSurfaceLayerPlugin, LoadsViaPluginlib)
+{
+  pluginlib::ClassLoader<nav2_costmap_2d::Layer> loader(
+    "nav2_costmap_2d", "nav2_costmap_2d::Layer");
+
+  std::shared_ptr<nav2_costmap_2d::Layer> producer;
+  ASSERT_NO_THROW(
+    producer = loader.createSharedInstance("sea_surface_layer::SeaSurfaceLayer"));
+  EXPECT_NE(producer, nullptr);
+
+  std::shared_ptr<nav2_costmap_2d::Layer> relay;
+  ASSERT_NO_THROW(
+    relay = loader.createSharedInstance("sea_surface_layer::SeaSurfaceRelayLayer"));
+  EXPECT_NE(relay, nullptr);
+}
+
+// Initialize the SeaSurfaceLayer against a real LayeredCostmap + LifecycleNode.
+// This exercises `onInitialize` — the path that, before this regression test
+// existed, hid a declaration-order bug from the unit-test set: registering
+// `add_on_set_parameters_callback` *before* `declareParameter("published_topic")`
+// caused the callback's configure-time rejection to fire during
+// `declare_parameter`'s initial-value validation, throwing
+// `InvalidParameterValueException` and aborting `onInitialize`. The layer
+// would fail to load at deployment time but every GTest passed because none
+// exercised the pluginlib initialization path.
+//
+// Keep this test guard-rail tight: a regression in declaration order, in any
+// `declareParameter` validation in `onInitialize`, or in the param callback's
+// `is_configure_time` matcher will all surface here as an `onInitialize` throw.
+class LayerInitializeFixture : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<nav2_util::LifecycleNode>("test_sea_surface_layer");
+    // The Layer constructor reads `layered_costmap_->getCostmap()`; size it
+    // non-zero so the layer's `matchSize()` builds a valid `OccupancyBuffer`.
+    parent_ = std::make_unique<nav2_costmap_2d::LayeredCostmap>(
+      "map", /*rolling_window=*/false, /*track_unknown=*/false);
+    parent_->resizeMap(/*size_x_cells=*/10, /*size_y_cells=*/10,
+      /*resolution=*/1.0, /*origin_x=*/0.0, /*origin_y=*/0.0);
+    tf_ = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
+    callback_group_ = node_->create_callback_group(
+      rclcpp::CallbackGroupType::Reentrant);
+    loader_ = std::make_unique<pluginlib::ClassLoader<nav2_costmap_2d::Layer>>(
+      "nav2_costmap_2d", "nav2_costmap_2d::Layer");
+  }
+
+  void TearDown() override
+  {
+    loader_.reset();
+    tf_.reset();
+    parent_.reset();
+    node_.reset();
+    rclcpp::shutdown();
+  }
+
+  std::shared_ptr<nav2_util::LifecycleNode> node_;
+  std::unique_ptr<nav2_costmap_2d::LayeredCostmap> parent_;
+  std::unique_ptr<tf2_ros::Buffer> tf_;
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
+  std::unique_ptr<pluginlib::ClassLoader<nav2_costmap_2d::Layer>> loader_;
+};
+
+TEST_F(LayerInitializeFixture, SeaSurfaceLayerInitializesWithoutThrow)
+{
+  auto plugin = loader_->createSharedInstance("sea_surface_layer::SeaSurfaceLayer");
+  ASSERT_NE(plugin, nullptr);
+  ASSERT_NO_THROW(
+    plugin->initialize(parent_.get(), "sea_surface_layer", tf_.get(),
+      node_, callback_group_));
+}
+
+TEST_F(LayerInitializeFixture, SeaSurfaceRelayLayerInitializesWithoutThrow)
+{
+  auto plugin = loader_->createSharedInstance("sea_surface_layer::SeaSurfaceRelayLayer");
+  ASSERT_NE(plugin, nullptr);
+  ASSERT_NO_THROW(
+    plugin->initialize(parent_.get(), "sea_surface_relay", tf_.get(),
+      node_, callback_group_));
+}

--- a/sea_surface_segmentation/test/test_occupancy_buffer.cpp
+++ b/sea_surface_segmentation/test/test_occupancy_buffer.cpp
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <string>
+
+#include <grid_map_core/grid_map_core.hpp>
+
+#include "occupancy_buffer.hpp"
+
+using sea_surface_segmentation::OccupancyBuffer;
+using sea_surface_segmentation::OccupancyParams;
+
+namespace
+{
+// 4 m square @ 0.25 m → 16×16 cells, centered at the origin. Roomy enough to
+// roll the window and still have an overlap region and a newly-exposed region.
+OccupancyBuffer make_buffer(const OccupancyParams & p = OccupancyParams{})
+{
+  return OccupancyBuffer(4.0, 4.0, 0.25, grid_map::Position(0.0, 0.0), p);
+}
+const grid_map::Position kP(0.3, 0.0);  // a representative observed cell
+}  // namespace
+
+// A single obstacle observation must NOT mark a cell lethal — this is the
+// flicker rejection that the per-frame-reset layer lacked (one stray
+// segmentation pixel shouldn't become an obstacle).
+TEST(OccupancyBuffer, SingleObservationBelowThreshold)
+{
+  auto buf = make_buffer();  // hit=0.85, threshold=1.0
+  EXPECT_TRUE(buf.hit(kP));
+  EXPECT_NEAR(buf.logOdds(kP), 0.85, 1e-5);
+  EXPECT_FALSE(buf.isLethal(kP)) << "one observation < threshold must not be lethal";
+}
+
+// Repeated observations accumulate past the threshold — the obstacle is
+// remembered once it's confirmed.
+TEST(OccupancyBuffer, RepeatedObservationsCrossThreshold)
+{
+  auto buf = make_buffer();
+  buf.hit(kP);
+  buf.hit(kP);
+  EXPECT_NEAR(buf.logOdds(kP), 1.70, 1e-5);
+  EXPECT_TRUE(buf.isLethal(kP));
+}
+
+// Free-space (water) observations drive an obstacle back below the threshold —
+// the layer can clear a stale mark when it sees water there.
+TEST(OccupancyBuffer, FreeObservationsClearObstacle)
+{
+  auto buf = make_buffer();
+  buf.hit(kP); buf.hit(kP); buf.hit(kP);  // 2.55 → lethal
+  ASSERT_TRUE(buf.isLethal(kP));
+  buf.miss(kP); buf.miss(kP); buf.miss(kP); buf.miss(kP);  // -1.6 → 0.95
+  EXPECT_NEAR(buf.logOdds(kP), 0.95, 1e-5);
+  EXPECT_FALSE(buf.isLethal(kP));
+}
+
+// Evidence is bounded so it stays revisable (no runaway saturation that would
+// take forever to clear).
+TEST(OccupancyBuffer, ClampBoundsEvidence)
+{
+  auto buf = make_buffer();  // clamp = 5.0
+  for (int i = 0; i < 20; ++i) { buf.hit(kP); }
+  EXPECT_NEAR(buf.logOdds(kP), 5.0, 1e-5);
+  for (int i = 0; i < 40; ++i) { buf.miss(kP); }
+  EXPECT_NEAR(buf.logOdds(kP), -5.0, 1e-5);
+}
+
+// A never-observed cell is unknown (NaN), not free and not lethal.
+TEST(OccupancyBuffer, UnobservedCellIsUnknown)
+{
+  auto buf = make_buffer();
+  EXPECT_TRUE(std::isnan(buf.logOdds(kP)));
+  EXPECT_FALSE(buf.isLethal(kP));
+}
+
+// "Remember, but not forever": a confirmed obstacle decays back below the
+// threshold once it stops being observed, and toward the prior over time.
+TEST(OccupancyBuffer, DecayForgetsObstacleOverTime)
+{
+  auto buf = make_buffer();  // half-life 30 s
+  buf.hit(kP); buf.hit(kP);  // 1.70 → lethal
+  buf.decay(0.0);            // first call only seeds the clock
+  EXPECT_TRUE(buf.isLethal(kP)) << "no time elapsed yet";
+  buf.decay(25.0);           // 1.70 * 0.5^(25/30) ≈ 0.954
+  EXPECT_NEAR(buf.logOdds(kP), 1.70 * std::pow(0.5, 25.0 / 30.0), 1e-4);
+  EXPECT_FALSE(buf.isLethal(kP)) << "decayed below threshold";
+  buf.decay(1000.0);
+  EXPECT_LT(std::fabs(buf.logOdds(kP)), 0.01) << "decays toward the prior (0)";
+}
+
+// MUST-FIX #1: rolling the window by a *sequence of fractional-meter* shifts
+// must preserve accumulated evidence at its true world cell (not drift it to a
+// neighbour or wipe it), and newly-exposed cells must read as unobserved.
+TEST(OccupancyBuffer, FractionalShiftsPreserveEvidenceAtWorldCell)
+{
+  auto buf = make_buffer();
+  buf.hit(kP); buf.hit(kP);  // lethal at world (0.3, 0)
+  ASSERT_TRUE(buf.isLethal(kP));
+
+  // Roll the window through sub-cell (0.25 m) origin steps to an end center of
+  // (1.0, 0). kP stays inside the window throughout.
+  buf.move(grid_map::Position(0.3, 0.0));
+  buf.move(grid_map::Position(0.6, 0.0));
+  buf.move(grid_map::Position(1.0, 0.0));
+
+  EXPECT_TRUE(buf.isLethal(kP))
+    << "evidence must survive fractional rolling at its world location";
+
+  // A cell that was outside the original window (|x|<=2) but inside the rolled
+  // one (x in [-1,3]) must be unobserved, not lethal.
+  const grid_map::Position exposed(2.5, 0.0);
+  EXPECT_TRUE(std::isnan(buf.logOdds(exposed)));
+  EXPECT_FALSE(buf.isLethal(exposed));
+}
+
+// Out-of-window observations are no-ops (don't throw, don't mark).
+TEST(OccupancyBuffer, OutOfBoundsObservationIsNoOp)
+{
+  auto buf = make_buffer();
+  const grid_map::Position outside(100.0, 100.0);
+  EXPECT_FALSE(buf.hit(outside));
+  EXPECT_FALSE(buf.isLethal(outside));
+}
+
+// Parameter validation rejects values that would corrupt the buffer's meaning —
+// the guard for runtime `ros2 param set` on a safety layer.
+TEST(OccupancyBuffer, ValidateRejectsBadParams)
+{
+  std::string why;
+  EXPECT_TRUE(OccupancyBuffer::validate(OccupancyParams{}, why)) << why;
+
+  OccupancyParams p;
+  p.hit_log_odds = -1.0;  // must be > 0
+  EXPECT_FALSE(OccupancyBuffer::validate(p, why));
+
+  p = OccupancyParams{}; p.miss_log_odds = 0.5;  // must be < 0
+  EXPECT_FALSE(OccupancyBuffer::validate(p, why));
+
+  p = OccupancyParams{}; p.decay_half_life_s = 0.0;  // must be > 0
+  EXPECT_FALSE(OccupancyBuffer::validate(p, why));
+
+  p = OccupancyParams{}; p.lethal_threshold = 99.0;  // must be <= clamp
+  EXPECT_FALSE(OccupancyBuffer::validate(p, why));
+
+  p = OccupancyParams{}; p.hit_log_odds = std::nan("");  // finite required
+  EXPECT_FALSE(OccupancyBuffer::validate(p, why));
+}

--- a/sea_surface_segmentation/test/test_occupancy_buffer.cpp
+++ b/sea_surface_segmentation/test/test_occupancy_buffer.cpp
@@ -171,3 +171,24 @@ TEST(OccupancyBuffer, ValidateRejectsBadParams)
   p = OccupancyParams{}; p.hit_log_odds = std::nan("");  // finite required
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 }
+
+// setParams reinterprets accumulated evidence immediately — a single hit that
+// sat just under the default lethal_threshold (1.0) becomes lethal once a
+// lower threshold (0.3) is applied at runtime, without re-observing the cell.
+// This is the live-tunable contract the layer's param callback relies on
+// (`SeaSurfaceLayer::onParametersSet` → `OccupancyBuffer::setParams`).
+TEST(OccupancyBuffer, SetParamsReinterpretsAccumulatedEvidence)
+{
+  auto buf = make_buffer();  // defaults: hit=0.85, threshold=1.0
+  EXPECT_TRUE(buf.hit(kP));
+  EXPECT_FALSE(buf.isLethal(kP)) << "0.85 < 1.0, not yet lethal at default threshold";
+
+  OccupancyParams looser = OccupancyParams{};
+  looser.lethal_threshold = 0.3;  // < 0.85; same accumulated evidence now reads lethal
+  std::string why;
+  ASSERT_TRUE(OccupancyBuffer::validate(looser, why)) << why;
+  buf.setParams(looser);
+
+  EXPECT_TRUE(buf.isLethal(kP))
+    << "lowered threshold must reinterpret accumulated 0.85 log-odds as lethal";
+}

--- a/sea_surface_segmentation/test/test_occupancy_buffer.cpp
+++ b/sea_surface_segmentation/test/test_occupancy_buffer.cpp
@@ -89,16 +89,35 @@ TEST(OccupancyBuffer, DecayForgetsObstacleOverTime)
   EXPECT_LT(std::fabs(buf.logOdds(kP)), 0.01) << "decays toward the prior (0)";
 }
 
-// MUST-FIX #1: rolling the window by a *sequence of fractional-meter* shifts
-// must preserve accumulated evidence at its true world cell (not drift it to a
-// neighbour or wipe it), and newly-exposed cells must read as unobserved.
-TEST(OccupancyBuffer, FractionalShiftsPreserveEvidenceAtWorldCell)
+// A backward time jump (clock reset / sim-time discontinuity) must not decay and
+// must not rewind the decay reference: evidence is held, and the next forward
+// step measures true elapsed time from the original reference (not the blip).
+TEST(OccupancyBuffer, BackwardTimeDoesNotDecayOrRewind)
+{
+  auto buf = make_buffer();  // half-life 30 s
+  buf.hit(kP); buf.hit(kP);  // 1.70 → lethal
+  buf.decay(100.0);          // seed reference at t=100
+  buf.decay(50.0);           // backward: must not decay, must not rewind reference
+  EXPECT_NEAR(buf.logOdds(kP), 1.70, 1e-5) << "backward time must not decay";
+  EXPECT_TRUE(buf.isLethal(kP));
+  buf.decay(130.0);          // dt measured from 100 (not 50) → exactly one half-life
+  EXPECT_NEAR(buf.logOdds(kP), 0.85, 1e-4)
+    << "elapsed measured from the held reference, not the backward blip";
+}
+
+// Rolling the window through a sequence of origin shifts must preserve
+// accumulated evidence at its true world cell (not drift it to a neighbour or
+// wipe it), and newly-exposed cells must read as unobserved. grid_map's move()
+// snaps each shift to whole cells and carries the sub-cell residual internally,
+// so this exercises no-drift-across-rolling + exposed-unobserved — the core of
+// review-plan must-fix #1 — rather than the residual arithmetic itself.
+TEST(OccupancyBuffer, RollingPreservesEvidenceAtWorldCell)
 {
   auto buf = make_buffer();
   buf.hit(kP); buf.hit(kP);  // lethal at world (0.3, 0)
   ASSERT_TRUE(buf.isLethal(kP));
 
-  // Roll the window through sub-cell (0.25 m) origin steps to an end center of
+  // Roll the window through successive origin steps to an end center of
   // (1.0, 0). kP stays inside the window throughout.
   buf.move(grid_map::Position(0.3, 0.0));
   buf.move(grid_map::Position(0.6, 0.0));
@@ -141,6 +160,12 @@ TEST(OccupancyBuffer, ValidateRejectsBadParams)
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 
   p = OccupancyParams{}; p.lethal_threshold = 99.0;  // must be <= clamp
+  EXPECT_FALSE(OccupancyBuffer::validate(p, why));
+
+  p = OccupancyParams{}; p.lethal_threshold = 0.0;   // must be > 0 (else 1 hit = lethal)
+  EXPECT_FALSE(OccupancyBuffer::validate(p, why));
+
+  p = OccupancyParams{}; p.lethal_threshold = -1.0;  // negative inverts safety (water => lethal)
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 
   p = OccupancyParams{}; p.hit_log_odds = std::nan("");  // finite required

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -16,6 +16,7 @@
 using sea_surface_segmentation::is_obstacle_pixel;
 using sea_surface_segmentation::is_waterline_contact_pixel;
 using sea_surface_segmentation::project_observations;
+using sea_surface_segmentation::project_observations_inverse;
 using sea_surface_segmentation::OccupancyObservation;
 using sea_surface_segmentation::project_obstacle_pixels;
 using sea_surface_segmentation::ProjectedPoint;
@@ -517,4 +518,71 @@ TEST(ProjectObservations, IsolatedContactIsObstacle)
   auto [obstacle, free] = count_obs(obs);
   EXPECT_EQ(obstacle, 1);
   EXPECT_EQ(free, 16 * 12 - 1);
+}
+
+// ---- project_observations_inverse: the per-cell→pixel classifier the layer uses
+//      (and the offline utility shares). Cell-iteration centred on (cx,cy);
+//      same contact-only marking + sky-skip semantics. ----
+
+// All-water mask → every in-footprint cell is missed (free); no obstacles.
+TEST(ProjectObservationsInverse, AllWaterAllMisses)
+{
+  cv::Mat mask(12, 16, CV_8UC3, cv::Scalar(0, 200, 0));  // green-dominant = water
+  const auto obs = project_observations_inverse(
+    mask, make_small_nadir_camera(), kNadirOrigin, nadir_rotation(),
+    /*max_range=*/100.0, /*cx=*/0.0, /*cy=*/0.0, /*res=*/0.2, /*half_extent=*/1.5);
+  auto [obstacle, free] = count_obs(obs);
+  EXPECT_EQ(obstacle, 0);
+  EXPECT_GT(free, 0) << "every in-footprint cell should be classified as water-miss";
+}
+
+// All-sky mask → every cell projects to a sky pixel → SKIP (no obs), not miss.
+// The sky-as-miss bug would over-clear cells; sky-skip preserves them.
+TEST(ProjectObservationsInverse, AllSkyAllSkippedNotCleared)
+{
+  cv::Mat mask(12, 16, CV_8UC3, cv::Scalar(0, 0, 200));  // blue-dominant = sky
+  const auto obs = project_observations_inverse(
+    mask, make_small_nadir_camera(), kNadirOrigin, nadir_rotation(),
+    /*max_range=*/100.0, /*cx=*/0.0, /*cy=*/0.0, /*res=*/0.2, /*half_extent=*/1.5);
+  EXPECT_TRUE(obs.empty()) << "sky-projecting cells must be skipped, not marked free";
+}
+
+// A column with a 2-px-tall obstacle above water: only cells projecting to the
+// contact row (lowest obstacle pixel) produce a hit; cells projecting to the
+// body pixel above are skipped (occluded); water cells around → miss.
+TEST(ProjectObservationsInverse, ContactCellHitsBodyCellsSkipped)
+{
+  cv::Mat mask(12, 16, CV_8UC3, cv::Scalar(0, 200, 0));  // water everywhere
+  // 2-tall obstacle in column 8: rows 5 (body) and 6 (contact), water row 7+.
+  mask.at<cv::Vec3b>(5, 8) = cv::Vec3b(200, 0, 0);
+  mask.at<cv::Vec3b>(6, 8) = cv::Vec3b(200, 0, 0);
+  const auto obs = project_observations_inverse(
+    mask, make_small_nadir_camera(), kNadirOrigin, nadir_rotation(),
+    /*max_range=*/100.0, /*cx=*/0.0, /*cy=*/0.0, /*res=*/0.2, /*half_extent=*/1.5);
+  auto [obstacle, free] = count_obs(obs);
+  EXPECT_GT(obstacle, 0) << "the contact cell must produce at least one hit";
+  EXPECT_GT(free, 0) << "water cells must still be missed";
+  // The body pixel above the contact is occluded; no cell should be flagged as
+  // obstacle there. Verify by ensuring obstacle count is bounded — the contact
+  // is one pixel, so only cells projecting to that one pixel become hits.
+  EXPECT_LE(obstacle, 4) << "only the contact-pixel's cell footprint is hit, not the body's";
+}
+
+// Cells beyond max_range (even when in-image) are dropped by the Euclidean
+// range gate. With camera at z=2 and max_range=2.05, only the cells directly
+// under (slant distance ≈ 2.0–2.05 m) survive; an iteration covering several
+// metres horizontally should produce far fewer observations than the same
+// iteration with a generous range cap.
+TEST(ProjectObservationsInverse, MaxRangeDropsFarCells)
+{
+  cv::Mat mask(12, 16, CV_8UC3, cv::Scalar(0, 200, 0));
+  const auto loose = project_observations_inverse(
+    mask, make_small_nadir_camera(), kNadirOrigin, nadir_rotation(),
+    /*max_range=*/100.0, 0.0, 0.0, 0.2, 1.5);
+  const auto tight = project_observations_inverse(
+    mask, make_small_nadir_camera(), kNadirOrigin, nadir_rotation(),
+    /*max_range=*/2.05, 0.0, 0.0, 0.2, 1.5);
+  EXPECT_LT(tight.size(), loose.size())
+    << "tight max_range must drop far cells the loose range admits";
+  EXPECT_GT(tight.size(), 0u) << "near-overhead cells should still pass the tight gate";
 }

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -588,6 +588,50 @@ TEST(ProjectObservationsInverse, MaxRangeDropsFarCells)
   EXPECT_GT(tight.size(), 0u) << "near-overhead cells should still pass the tight gate";
 }
 
+// Minimum grazing angle cuts off rays that hit the water plane too shallowly.
+// At camera height h, a min-grazing angle of θ enforces max horizontal range
+// ≈ h / tan(θ). Use a nadir camera so all rays straight down have grazing 90°
+// (every cell passes any cutoff < 90°), then a pitched camera so the cutoff
+// actually starts dropping cells at the expected horizontal range.
+TEST(ProjectObservationsInverse, MinGrazingAngleDropsShallowRays)
+{
+  cv::Mat mask(12, 16, CV_8UC3, cv::Scalar(0, 200, 0));  // water everywhere
+
+  // Pitched 30°, camera at 1.5 m, iteration centred at camera XY out to 50 m.
+  // No grazing cutoff: many cells observed.
+  image_geometry::PinholeCameraModel cam;
+  cam.fromCameraInfo(make_pinhole_info(160, 120, 100.0, 100.0));  // larger img so more rays land in-image
+  const cv::Vec3d camera_origin(0.0, 0.0, 1.5);
+  const auto rotation = pitched_rotation(30.0);
+
+  const auto loose = project_observations_inverse(
+    mask, cam, camera_origin, rotation,
+    /*max_range=*/100.0, /*cx=*/10.0, /*cy=*/0.0, /*res=*/0.5,
+    /*half_extent=*/15.0, /*plane_z=*/0.0, /*min_grazing_angle_deg=*/0.0);
+
+  // Tight grazing cutoff at 30° → max horizontal range = 1.5 / tan(30°) = 2.6 m.
+  // Cells beyond ~2.6 m horizontal (from the camera at origin) must drop.
+  const auto tight = project_observations_inverse(
+    mask, cam, camera_origin, rotation,
+    /*max_range=*/100.0, /*cx=*/10.0, /*cy=*/0.0, /*res=*/0.5,
+    /*half_extent=*/15.0, /*plane_z=*/0.0, /*min_grazing_angle_deg=*/30.0);
+
+  ASSERT_GT(loose.size(), 0u);
+  EXPECT_LT(tight.size(), loose.size())
+    << "min_grazing_angle_deg must drop shallow-grazing cells";
+
+  // Every cell that survives the tight cutoff must hit the water plane at >= 30°.
+  // For a cell at (x, y, 0) viewed from (0, 0, 1.5), grazing angle is
+  // atan(1.5 / sqrt(x*x + y*y)). 30° → sqrt(x*x + y*y) <= 1.5 / tan(30°) ≈ 2.598.
+  const double max_horiz = 1.5 / std::tan(30.0 * M_PI / 180.0);
+  for (const auto & o : tight) {
+    const double horiz = std::sqrt(o.x * o.x + o.y * o.y);
+    EXPECT_LE(horiz, max_horiz + 1e-6)
+      << "cell at horizontal range " << horiz << " exceeds grazing-30° reach "
+      << max_horiz << " — cutoff is wrong";
+  }
+}
+
 // Pitched, off-centre camera — the production call shape. Exercises three gaps
 // in the nadir tests: (a) off-centre iteration (cx,cy = camera XY, not 0), (b)
 // the pc[2] <= 0 behind-camera reject, (c) body-vs-contact occlusion under

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -587,3 +587,78 @@ TEST(ProjectObservationsInverse, MaxRangeDropsFarCells)
     << "tight max_range must drop far cells the loose range admits";
   EXPECT_GT(tight.size(), 0u) << "near-overhead cells should still pass the tight gate";
 }
+
+// Pitched, off-centre camera — the production call shape. Exercises three gaps
+// in the nadir tests: (a) off-centre iteration (cx,cy = camera XY, not 0), (b)
+// the pc[2] <= 0 behind-camera reject, (c) body-vs-contact occlusion under
+// non-trivial geometry — only cells projecting to the contact row (the lowest
+// obstacle pixel with water directly below) produce hits; cells projecting to
+// body pixels above are skipped. Camera at world (5, 3, 1.5), pitched 30° down
+// looking +x; iteration centred at the camera's XY so the back half of the
+// window (wx < 5) sits behind the camera and must be silently rejected.
+//
+// Note on `v == contact_row[u]` vs the previous `v >= contact_row[u]`: the two
+// forms are functionally equivalent against the `is_waterline_contact_pixel`
+// definition. The contact is the lowest obstacle pixel with water directly
+// below, OR an obstacle pixel on the bottom image row (treated as a contact
+// since nothing below can disqualify it). Any obstacle pixel below the
+// recorded contact would therefore extend an unbroken obstacle column down to
+// the image bottom — which makes the bottom row a contact by the
+// special case, displacing the recorded contact lower. So no real mask reaches
+// the `v > contact_row[u]` branch. The `==` form is preferred purely for
+// consistency with the forward sibling `project_observations`.
+TEST(ProjectObservationsInverse, PitchedOffCentreRejectsBehindAndOccludesBody)
+{
+  cv::Mat mask(12, 16, CV_8UC3, cv::Scalar(0, 200, 0));  // water everywhere
+  // Two-pixel-tall obstacle in column 8: row 6 (body, above contact, occluded)
+  // and row 7 (contact, water at row 8 directly below). The body row must NOT
+  // produce hits; the contact row must produce at least one.
+  mask.at<cv::Vec3b>(6, 8) = cv::Vec3b(200, 0, 0);
+  mask.at<cv::Vec3b>(7, 8) = cv::Vec3b(200, 0, 0);
+
+  image_geometry::PinholeCameraModel cam;
+  cam.fromCameraInfo(make_pinhole_info(16, 12, 10.0, 10.0));
+  const cv::Vec3d camera_origin(5.0, 3.0, 1.5);
+
+  const auto obs = project_observations_inverse(
+    mask, cam, camera_origin, pitched_rotation(30.0),
+    /*max_range=*/50.0, /*cx=*/5.0, /*cy=*/3.0, /*res=*/0.2, /*half_extent=*/6.0);
+
+  ASSERT_FALSE(obs.empty()) << "in-front in-FOV cells should produce some observations";
+
+  int behind = 0, hits = 0;
+  for (const auto & o : obs) {
+    if (o.x < camera_origin[0] - 1e-9) { ++behind; }
+    if (o.obstacle) { ++hits; }
+  }
+  EXPECT_EQ(behind, 0)
+    << "cells behind the camera (wx < camera_x) must be rejected by pc[2] <= 0";
+  EXPECT_GT(hits, 0)
+    << "the contact row must produce at least one hit under a pitched camera";
+
+  // Off-centre iteration: observed cells should cluster around the camera XY,
+  // not the world origin. With cy=3 and half_extent=6, observations span y ∈
+  // roughly [-3, 9] — the principal-point ray hits y = 3, so at least one
+  // observation must have |y - 3| < 1 m.
+  bool any_near_camera_y = false;
+  for (const auto & o : obs) {
+    if (std::abs(o.y - camera_origin[1]) < 1.0) { any_near_camera_y = true; break; }
+  }
+  EXPECT_TRUE(any_near_camera_y)
+    << "iteration should be centred at cy=" << camera_origin[1] << ", not 0";
+
+  // Body-vs-contact occlusion under pitched geometry: every hit must come from
+  // a cell projecting to the contact row 7, not body row 6. For this geometry
+  // (camera at z=1.5, 30° pitch, fy=10, cy=6), the contact-row ground
+  // intersection is at world x ≈ 7.09; the body row 6 (principal point) lies
+  // at x ≈ 7.60. Bound hits to x < 7.30 — covers contact-row cells with margin
+  // while excluding body-row cells.
+  for (const auto & o : obs) {
+    if (o.obstacle) {
+      EXPECT_LT(o.x, 7.30)
+        << "hit at x=" << o.x << " is beyond the contact-row reach — body "
+           "row (row 6) appears to be marking, indicating body-vs-contact "
+           "occlusion broke under pitched geometry";
+    }
+  }
+}

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cmath>
+#include <utility>
 #include <vector>
 
 #include <opencv2/core.hpp>

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -15,6 +15,8 @@
 
 using sea_surface_segmentation::is_obstacle_pixel;
 using sea_surface_segmentation::is_waterline_contact_pixel;
+using sea_surface_segmentation::project_observations;
+using sea_surface_segmentation::OccupancyObservation;
 using sea_surface_segmentation::project_obstacle_pixels;
 using sea_surface_segmentation::ProjectedPoint;
 using sea_surface_segmentation::ProjectionStats;
@@ -450,4 +452,69 @@ TEST(ProjectObstaclePixels, StatsAccountForPixelsAndProjections)
   EXPECT_EQ(stats.obstacle_pixels, 1u);
   EXPECT_EQ(stats.projected, 1u);
   EXPECT_EQ(stats.dropped_nonfinite, 0u);
+}
+
+// ---- project_observations: the shared per-frame logic (waterline-contact +
+//      occlusion + water-as-free) used by both the layer and the bag utility. ----
+
+namespace
+{
+// Small nadir camera (16×12 @ fx=fy=10, 2 m up looking straight down) so every
+// pixel projects to a valid ground point — lets the classification counts be
+// asserted exactly without geometry dropping pixels.
+image_geometry::PinholeCameraModel make_small_nadir_camera()
+{
+  image_geometry::PinholeCameraModel m;
+  m.fromCameraInfo(make_pinhole_info(16, 12, 10.0, 10.0));
+  return m;
+}
+const cv::Vec3d kNadirOrigin(0.0, 0.0, 2.0);
+
+std::pair<int, int> count_obs(const std::vector<OccupancyObservation> & obs)
+{
+  int obstacle = 0, free = 0;
+  for (const auto & o : obs) { (o.obstacle ? obstacle : free)++; }
+  return {obstacle, free};
+}
+}  // namespace
+
+// All-water mask → every pixel is a free observation, no obstacles.
+TEST(ProjectObservations, AllWaterIsAllFree)
+{
+  cv::Mat mask(12, 16, CV_8UC3, cv::Scalar(0, 200, 0));  // green = water
+  const auto obs = project_observations(
+    mask, make_small_nadir_camera(), kNadirOrigin, nadir_rotation(), /*max_range=*/100.0);
+  auto [obstacle, free] = count_obs(obs);
+  EXPECT_EQ(obstacle, 0);
+  EXPECT_EQ(free, 16 * 12);
+}
+
+// A 3-pixel-tall obstacle in one column (rows 2,3,4, water below) yields exactly
+// ONE obstacle observation (the waterline contact, row 4); the two body pixels
+// are occluded and skipped (not free, not obstacle); all water → free. This is
+// the shadow/occlusion behavior.
+TEST(ProjectObservations, TallObstacleYieldsOneContactNotBody)
+{
+  cv::Mat mask(12, 16, CV_8UC3, cv::Scalar(0, 200, 0));
+  for (int row = 2; row <= 4; ++row) {
+    mask.at<cv::Vec3b>(row, 8) = cv::Vec3b(200, 0, 0);  // red = obstacle
+  }
+  const auto obs = project_observations(
+    mask, make_small_nadir_camera(), kNadirOrigin, nadir_rotation(), /*max_range=*/100.0);
+  auto [obstacle, free] = count_obs(obs);
+  EXPECT_EQ(obstacle, 1) << "only the waterline contact, not each body pixel";
+  EXPECT_EQ(free, 16 * 12 - 3) << "all water pixels free; 3 obstacle pixels are not free";
+  EXPECT_EQ(static_cast<int>(obs.size()), 16 * 12 - 2) << "2 body pixels skipped entirely";
+}
+
+// An isolated obstacle pixel with water directly below is a contact → 1 obstacle.
+TEST(ProjectObservations, IsolatedContactIsObstacle)
+{
+  cv::Mat mask(12, 16, CV_8UC3, cv::Scalar(0, 200, 0));
+  mask.at<cv::Vec3b>(6, 8) = cv::Vec3b(200, 0, 0);  // row 7 below is water
+  const auto obs = project_observations(
+    mask, make_small_nadir_camera(), kNadirOrigin, nadir_rotation(), /*max_range=*/100.0);
+  auto [obstacle, free] = count_obs(obs);
+  EXPECT_EQ(obstacle, 1);
+  EXPECT_EQ(free, 16 * 12 - 1);
 }

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -14,6 +14,7 @@
 #include "segments_projection.hpp"
 
 using sea_surface_segmentation::is_obstacle_pixel;
+using sea_surface_segmentation::is_waterline_contact_pixel;
 using sea_surface_segmentation::project_obstacle_pixels;
 using sea_surface_segmentation::ProjectedPoint;
 using sea_surface_segmentation::ProjectionStats;
@@ -112,6 +113,48 @@ TEST(IsObstaclePixel, NonRedDominantFalse)
   EXPECT_FALSE(is_obstacle_pixel(cv::Vec3b(0, 0, 200)));       // pure blue
   EXPECT_FALSE(is_obstacle_pixel(cv::Vec3b(200, 200, 200)));   // gray (ties don't dominate)
   EXPECT_FALSE(is_obstacle_pixel(cv::Vec3b(200, 200, 0)));     // red-tied-with-green
+}
+
+// is_waterline_contact_pixel: only the lowest obstacle pixel in a column
+// (the one with water directly below) is the waterline contact; obstacle
+// pixels stacked above it are the object's body and must NOT count as
+// contacts (their cells become the false "shadow").
+TEST(WaterlineContactPixel, OnlyLowestObstaclePixelInColumnIsContact)
+{
+  // 8x8 mask, all water (green). Column 4 holds a 3-px-tall obstacle in
+  // rows 2,3,4 with water below it (rows 5..7).
+  cv::Mat mask(8, 8, CV_8UC3, cv::Scalar(0, 200, 0));  // BGR-agnostic: G-dominant = water
+  for (int row = 2; row <= 4; ++row) {
+    mask.at<cv::Vec3b>(row, 4) = cv::Vec3b(200, 0, 0);  // R-dominant = obstacle
+  }
+
+  EXPECT_TRUE(is_waterline_contact_pixel(mask, 4, 4))   // base: water (row 5) below
+    << "lowest obstacle pixel in the column is the waterline contact";
+  EXPECT_FALSE(is_waterline_contact_pixel(mask, 3, 4))  // obstacle below (row 4)
+    << "body pixel with obstacle below is not a contact";
+  EXPECT_FALSE(is_waterline_contact_pixel(mask, 2, 4))  // obstacle below (row 3)
+    << "top body pixel is not a contact";
+}
+
+TEST(WaterlineContactPixel, WaterPixelIsNeverContact)
+{
+  cv::Mat mask(8, 8, CV_8UC3, cv::Scalar(0, 200, 0));
+  EXPECT_FALSE(is_waterline_contact_pixel(mask, 3, 3));
+}
+
+TEST(WaterlineContactPixel, ObstacleOnBottomRowIsContact)
+{
+  // Nothing below the bottom row to disqualify it → nearest possible return.
+  cv::Mat mask(8, 8, CV_8UC3, cv::Scalar(0, 200, 0));
+  mask.at<cv::Vec3b>(7, 4) = cv::Vec3b(200, 0, 0);
+  EXPECT_TRUE(is_waterline_contact_pixel(mask, 7, 4));
+}
+
+TEST(WaterlineContactPixel, IsolatedObstaclePixelWithWaterBelowIsContact)
+{
+  cv::Mat mask(8, 8, CV_8UC3, cv::Scalar(0, 200, 0));
+  mask.at<cv::Vec3b>(3, 4) = cv::Vec3b(200, 0, 0);  // single px, water below
+  EXPECT_TRUE(is_waterline_contact_pixel(mask, 3, 4));
 }
 
 // Center pixel under a nadir camera 1 m above the z=0 plane projects

--- a/sea_surface_segmentation/tools/bag_to_costmap_video.cpp
+++ b/sea_surface_segmentation/tools/bag_to_costmap_video.cpp
@@ -1,0 +1,482 @@
+// Offline replay: read recorded OAK segmentation from a bag, run it through the
+// corrected (inverse cell→pixel) projection + OccupancyBuffer, and render a review
+// MOSAIC per frame — so the layer's behavior can be seen on real water imagery,
+// alongside what the cameras saw and what the boat's live costmap held, before
+// deploying to the boat (#19).
+//
+// Mosaic layout (all costmap panels boat-centred, world-aligned, N-up):
+//   top row:    [ port | fwd | stbd | aft ]   (segmentation tiles, 4:3)
+//   bottom row: [ LIVE costmap (boat) | OURS (inverse, corrected) ]
+//
+// LIVE = the boat's own recorded /…/local_costmap/costmap, sampled into the same
+// boat-centred window for 1:1 comparison. OURS = occupancy_buffer fed by the
+// inverse projection (project_observations_inverse) — the corrected path. The
+// earlier forward-projection panel was dropped; the offline A/B that justified
+// the switch lives in git history / the #19 plan.
+//
+// Usage:
+//   bag_to_costmap_video <bag_uri> <out_dir> [--window-m 120] [--res 0.25]
+//       [--render-dt 0.2] [--max-range 150] [--start-s 0] [--end-s -1]
+// --start-s/--end-s window the replay to [start,end] seconds from bag start
+// (end<0 == to the end). The occupancy buffer accumulates from --start-s, so set
+// it a little before the moment of interest to give the buffer warm-up time.
+// Then: ffmpeg -framerate 10 -i <out_dir>/frame_%05d.png -pix_fmt yuv420p out.mp4
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <initializer_list>
+#include <limits>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+
+#include "cv_bridge/cv_bridge.hpp"
+#include "image_geometry/pinhole_camera_model.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "rclcpp/serialization.hpp"
+#include "rosbag2_cpp/reader.hpp"
+#include "sensor_msgs/msg/camera_info.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "tf2/buffer_core.h"
+#include "tf2/time.h"
+#include "tf2_msgs/msg/tf_message.hpp"
+
+#include "occupancy_buffer.hpp"
+#include "segments_projection.hpp"
+
+namespace
+{
+using sea_surface_segmentation::OccupancyBuffer;
+using sea_surface_segmentation::OccupancyParams;
+
+const std::array<const char *, 4> kCameras{"oak_forward", "oak_port", "oak_starboard", "oak_aft"};
+const std::string kWorldFrame = "bizzy/map_tide";
+const std::string kBoatFrame = "bizzy/base_link";
+const std::string kCostmapTopic = "/bizzy/local_costmap/costmap";
+
+double arg_double(int argc, char ** argv, const std::string & flag, double def)
+{
+  for (int i = 1; i + 1 < argc; ++i) {
+    if (flag == argv[i]) { return std::atof(argv[i + 1]); }
+  }
+  return def;
+}
+
+tf2::TimePoint to_tf_time(const builtin_interfaces::msg::Time & t)
+{
+  return tf2::TimePoint(
+    std::chrono::seconds(t.sec) + std::chrono::nanoseconds(t.nanosec));
+}
+
+template<typename T>
+T deserialize(const rosbag2_storage::SerializedBagMessageSharedPtr & msg)
+{
+  rclcpp::SerializedMessage serialized(*msg->serialized_data);
+  T out;
+  rclcpp::Serialization<T>().deserialize_message(&serialized, &out);
+  return out;
+}
+
+// Colour a log-odds value for the NEW-costmap render (BGR). Shared palette with
+// the LIVE render below so the two panels are read the same way.
+cv::Vec3b colour_logodds(double v, double threshold)
+{
+  if (std::isnan(v)) { return {110, 110, 110}; }          // unknown — grey
+  if (v >= threshold) { return {40, 40, 230}; }            // lethal — red
+  if (v > 0.0) {                                           // sub-threshold occupied — green→yellow
+    double f = std::min(v / threshold, 1.0);
+    return {30, static_cast<uchar>(120 + 100 * f), static_cast<uchar>(200 * f)};
+  }
+  return {70, 40, 20};                                     // free / negative — dark blue
+}
+
+// Colour a nav2 OccupancyGrid cost value (-1 unknown, 0 free, 100 lethal) with
+// the SAME palette as colour_logodds so LIVE and NEW compare apples-to-apples.
+cv::Vec3b colour_cost(int v)
+{
+  if (v < 0) { return {110, 110, 110}; }                   // NO_INFORMATION — grey
+  if (v >= 99) { return {40, 40, 230}; }                   // inscribed/lethal — red
+  if (v > 0) {                                             // intermediate cost — green→yellow
+    double f = std::min(v / 99.0, 1.0);
+    return {30, static_cast<uchar>(120 + 100 * f), static_cast<uchar>(200 * f)};
+  }
+  return {70, 40, 20};                                     // free — dark blue
+}
+
+// Render the NEW occupancy buffer into a boat-centred, world-aligned (N-up) panel.
+cv::Mat render_new(const OccupancyBuffer & buffer, double bx, double by,
+  int panel_px, double res, double threshold)
+{
+  cv::Mat panel(panel_px, panel_px, CV_8UC3);
+  for (int v = 0; v < panel_px; ++v) {
+    for (int u = 0; u < panel_px; ++u) {
+      const double wx = bx + (u - panel_px / 2) * res;
+      const double wy = by - (v - panel_px / 2) * res;  // image y down → world y up
+      panel.at<cv::Vec3b>(v, u) = colour_logodds(
+        buffer.logOdds(grid_map::Position(wx, wy)), threshold);
+    }
+  }
+  return panel;
+}
+
+// Render the LIVE recorded costmap into the same boat-centred window/scale so it
+// overlays the NEW panel 1:1. Samples the OccupancyGrid by world (x,y); the grid's
+// origin is in its own frame (bizzy/map), which shares the xy plane with map_tide
+// (the tide transform is z-only), so boat-xy and grid-xy are consistent.
+cv::Mat render_live(const nav_msgs::msg::OccupancyGrid & grid, bool have_grid,
+  double bx, double by, int panel_px, double res)
+{
+  cv::Mat panel(panel_px, panel_px, CV_8UC3, cv::Scalar(110, 110, 110));
+  if (!have_grid || grid.info.resolution <= 0.0) { return panel; }
+  const double ox = grid.info.origin.position.x;
+  const double oy = grid.info.origin.position.y;
+  const double gres = grid.info.resolution;
+  const int gw = static_cast<int>(grid.info.width);
+  const int gh = static_cast<int>(grid.info.height);
+  for (int v = 0; v < panel_px; ++v) {
+    for (int u = 0; u < panel_px; ++u) {
+      const double wx = bx + (u - panel_px / 2) * res;
+      const double wy = by - (v - panel_px / 2) * res;
+      const int gx = static_cast<int>(std::floor((wx - ox) / gres));
+      const int gy = static_cast<int>(std::floor((wy - oy) / gres));
+      int cost = -1;  // outside the live window reads as unknown
+      if (gx >= 0 && gx < gw && gy >= 0 && gy < gh) {
+        cost = grid.data[static_cast<std::size_t>(gy) * gw + gx];
+      }
+      panel.at<cv::Vec3b>(v, u) = colour_cost(cost);
+    }
+  }
+  return panel;
+}
+
+// PROTOTYPE — inverse (ground-up) projection, for A/B comparison against the
+// forward `project_observations`. Instead of mapping each image pixel to one cell,
+// it iterates the world cells in the boat-centred window and asks "which pixel
+// covers this cell?", so a single large/distant pixel fills EVERY cell in its
+// footprint (no gaps) and the search is naturally range-bounded to the window
+// (a near-horizon pixel can't smear past the window edge). Same contact-only
+// classification as the forward path: a cell that projects to its column's
+// waterline-contact pixel → obstacle; to water → free; to an above-contact body
+// pixel → skipped (occluded/unknown). Lives in the tool, not the shared header —
+// this is a comparison probe, not (yet) the layer's path.
+std::vector<sea_surface_segmentation::OccupancyObservation> project_observations_inverse(
+  const cv::Mat & mask, const image_geometry::PinholeCameraModel & cam,
+  const cv::Vec3d & cam_origin, const cv::Matx33d & rot_cam_to_world,
+  double max_range, double bx, double by, double res, double half_extent, double plane_z = 0.0)
+{
+  // Lowest (nearest) waterline contact per column — same primitive as forward.
+  std::vector<int> contact_row(mask.cols, -1);
+  for (int col = 0; col < mask.cols; ++col) {
+    for (int row = mask.rows - 1; row >= 0; --row) {
+      if (sea_surface_segmentation::is_waterline_contact_pixel(mask, row, col)) {
+        contact_row[col] = row;
+        break;
+      }
+    }
+  }
+
+  const cv::Matx33d rot_world_to_cam = rot_cam_to_world.t();
+  std::vector<sea_surface_segmentation::OccupancyObservation> obs;
+  const int n = static_cast<int>(std::lround(2.0 * half_extent / res));
+  for (int iy = 0; iy < n; ++iy) {
+    for (int ix = 0; ix < n; ++ix) {
+      const double wx = bx + (ix - n / 2) * res;
+      const double wy = by + (iy - n / 2) * res;
+      const cv::Vec3d d(wx - cam_origin[0], wy - cam_origin[1], plane_z - cam_origin[2]);
+      if (std::sqrt(d.dot(d)) > max_range) { continue; }     // beyond sensor range
+      const cv::Vec3d pc = rot_world_to_cam * d;             // cell in camera optical frame
+      if (pc[2] <= 0.0) { continue; }                        // behind the camera
+      const cv::Point2d uv = cam.project3dToPixel(cv::Point3d(pc[0], pc[1], pc[2]));
+      const int u = static_cast<int>(std::lround(uv.x));
+      const int v = static_cast<int>(std::lround(uv.y));
+      if (u < 0 || u >= mask.cols || v < 0 || v >= mask.rows) { continue; }
+      const cv::Vec3b px = mask.at<cv::Vec3b>(v, u);
+      // Class channels (rgb8): R=obstacle prob, G=water prob, B=sky prob.
+      // Only positively-observed water marks the cell free; sky/ambiguous → skip
+      // (a ground cell on z=0 sampling a sky pixel is a geometric inconsistency,
+      // and clearing on it would erase legitimate hits from other frames/cameras).
+      if (sea_surface_segmentation::is_obstacle_pixel(px)) {
+        if (contact_row[u] >= 0 && v >= contact_row[u]) {
+          obs.push_back({wx, wy, true});                     // waterline contact → hit
+        }
+        // else: above the contact = occluded body → unobserved
+      } else if (px[1] > px[0] && px[1] > px[2]) {           // green-dominant = water
+        obs.push_back({wx, wy, false});                      // positively observed water → miss
+      }
+      // else: sky (blue-dominant) or ambiguous → skip (no observation)
+    }
+  }
+  return obs;
+}
+
+void label(cv::Mat & img, const std::string & text, cv::Point org, double scale = 0.5)
+{
+  cv::putText(img, text, org, cv::FONT_HERSHEY_SIMPLEX, scale, {0, 0, 0}, 3);
+  cv::putText(img, text, org, cv::FONT_HERSHEY_SIMPLEX, scale, {255, 255, 255}, 1);
+}
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  if (argc < 3) {
+    std::fprintf(stderr,
+      "usage: %s <bag_uri> <out_dir> [--window-m 120] [--res 0.25] "
+      "[--render-dt 0.2] [--max-range 150] [--start-s 0] [--end-s -1]\n", argv[0]);
+    return 1;
+  }
+  const std::string bag_uri = argv[1];
+  const std::string out_dir = argv[2];
+  const double window_m = arg_double(argc, argv, "--window-m", 120.0);
+  const double res = arg_double(argc, argv, "--res", 0.25);
+  const double render_dt = arg_double(argc, argv, "--render-dt", 0.2);
+  const double max_range = arg_double(argc, argv, "--max-range", 150.0);
+  const double start_s = arg_double(argc, argv, "--start-s", 0.0);
+  const double end_s = arg_double(argc, argv, "--end-s", -1.0);
+
+  // Reject non-positive numeric args — a typoed `--res --window-m 200` would
+  // otherwise leave res=0 and divide-by-zero in panel_px / setGeometry; a
+  // negative window_m would make an invalid cv::Mat. start_s/end_s are
+  // intentionally allowed any sign (end_s < 0 means "to end of bag").
+  for (auto [name, val] : std::initializer_list<std::pair<const char *, double>>{
+    {"--window-m", window_m}, {"--res", res},
+    {"--render-dt", render_dt}, {"--max-range", max_range}})
+  {
+    if (!(val > 0.0)) {
+      std::fprintf(stderr, "error: %s must be > 0 (got %g)\n", name, val);
+      return 1;
+    }
+  }
+
+  OccupancyParams params;  // defaults — same as the layer's compiled-in defaults
+
+  // topic → camera name and the reverse, for placing each segmentation tile.
+  std::map<std::string, std::string> seg_topic_to_cam;
+  std::vector<std::string> seg_topics, info_topics;
+  for (const auto * cam : kCameras) {
+    const std::string seg = std::string("/bizzy/sensors/cameras/") + cam + "/segmentation";
+    seg_topic_to_cam[seg] = cam;
+    seg_topics.push_back(seg);
+    info_topics.push_back(seg + "/camera_info");
+  }
+  auto is_in = [](const std::vector<std::string> & v, const std::string & s) {
+    return std::find(v.begin(), v.end(), s) != v.end();
+  };
+
+  // ---- Pass 1: fill the TF buffer (whole-bag cache) + collect camera models. ----
+  tf2::BufferCore tf_buffer(tf2::durationFromSec(7200.0));
+  std::map<std::string, image_geometry::PinholeCameraModel> camera_models;  // keyed by optical frame
+  std::map<std::string, std::string> optical_to_cam;  // optical frame → camera name
+
+  std::fprintf(stderr, "pass 1: indexing tf + camera_info ...\n");
+  {
+    rosbag2_cpp::Reader reader;
+    reader.open(bag_uri);
+    while (reader.has_next()) {
+      auto bag_msg = reader.read_next();
+      const std::string & topic = bag_msg->topic_name;
+      if (topic == "/tf" || topic == "/tf_static") {
+        auto tfm = deserialize<tf2_msgs::msg::TFMessage>(bag_msg);
+        const bool is_static = (topic == "/tf_static");
+        for (const auto & tr : tfm.transforms) {
+          tf_buffer.setTransform(tr, "bag", is_static);
+        }
+      } else if (is_in(info_topics, topic)) {
+        auto info = deserialize<sensor_msgs::msg::CameraInfo>(bag_msg);
+        camera_models[info.header.frame_id].fromCameraInfo(info);
+        // /…/<cam>/segmentation/camera_info → <cam>
+        const std::string base = topic.substr(0, topic.size() - std::string("/camera_info").size());
+        if (seg_topic_to_cam.count(base)) {
+          optical_to_cam[info.header.frame_id] = seg_topic_to_cam[base];
+        }
+      }
+    }
+  }
+  std::fprintf(stderr, "  camera models: %zu\n", camera_models.size());
+
+  // ---- Pass 2: replay segmentation through the pipeline, render mosaic frames. ----
+  // Layout: top row = 4 camera tiles [ port | fwd | stbd | aft ];
+  //         bottom row = [ LIVE costmap (boat) | OURS (inverse, corrected) ].
+  const int panel_px = static_cast<int>(std::lround(window_m / res));  // costmap panel (square)
+  const int cam_w = panel_px / 2;            // 4 tiles span the 2-panel bottom width
+  const int cam_h = cam_w * 3 / 4;           // 128x96 mask is 4:3
+  const int header_px = 22;                  // label band above each row
+  const int canvas_w = panel_px * 2;
+  const int cam_row_y = header_px;                        // camera tiles start here
+  const int cm_label_y = header_px + cam_h;              // costmap label band
+  const int cm_row_y = cm_label_y + header_px;           // costmap panels start here
+  const int canvas_h = cm_row_y + panel_px;
+  const double half_extent = window_m / 2.0;
+  OccupancyBuffer buffer(window_m, window_m, res, grid_map::Position(0.0, 0.0), params);
+
+  // Camera tiles left→right: port, forward, starboard, aft.
+  const std::array<const char *, 4> cam_order{"oak_port", "oak_forward", "oak_starboard", "oak_aft"};
+  std::map<std::string, cv::Mat> latest_mask_bgr;  // camera name → latest seg (BGR, for display)
+
+  nav_msgs::msg::OccupancyGrid live_costmap;
+  bool have_costmap = false;
+  std::string live_frame_reported;
+
+  std::fprintf(stderr, "pass 2: replaying (panel %dx%d, canvas %dx%d) window [%.0f, %.0f]s ...\n",
+    panel_px, panel_px, canvas_w, canvas_h, start_s, end_s);
+  rosbag2_cpp::Reader reader;
+  reader.open(bag_uri);
+  const int64_t bag_start_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+    reader.get_metadata().starting_time.time_since_epoch()).count();
+  const int64_t start_ns = bag_start_ns + static_cast<int64_t>(start_s * 1e9);
+  const int64_t end_ns = (end_s < 0.0) ? std::numeric_limits<int64_t>::max()
+    : bag_start_ns + static_cast<int64_t>(end_s * 1e9);
+
+  double last_render = -1.0;
+  int frame_idx = 0;
+  long processed = 0;
+  // Per-camera accounting so a silently-dropped camera (bad TF, no obs) is
+  // observable instead of just a blank tile / empty quadrant. `obs_inv_cells`
+  // counts world cells the inverse projection actually applied hit/miss to
+  // (different unit from the forward path's per-pixel counts — don't compare
+  // to historical numbers).
+  std::map<std::string, long> seg_seen, tf_fail, obs_inv_cells;
+
+  while (reader.has_next()) {
+    auto bag_msg = reader.read_next();
+    if (bag_msg->recv_timestamp < start_ns) { continue; }
+    if (bag_msg->recv_timestamp > end_ns) { break; }
+    const std::string & topic = bag_msg->topic_name;
+
+    if (topic == kCostmapTopic) {
+      live_costmap = deserialize<nav_msgs::msg::OccupancyGrid>(bag_msg);
+      have_costmap = true;
+      if (live_frame_reported.empty()) {
+        live_frame_reported = live_costmap.header.frame_id;
+        std::fprintf(stderr, "  live costmap frame: '%s' (res %.3f m, %ux%u)\n",
+          live_frame_reported.c_str(), live_costmap.info.resolution,
+          live_costmap.info.width, live_costmap.info.height);
+      }
+      continue;
+    }
+    if (!is_in(seg_topics, topic)) { continue; }
+
+    auto img_msg = deserialize<sensor_msgs::msg::Image>(bag_msg);
+    const std::string & optical_frame = img_msg.header.frame_id;
+    auto model_it = camera_models.find(optical_frame);
+    if (model_it == camera_models.end()) { continue; }
+    const double stamp_s = img_msg.header.stamp.sec + img_msg.header.stamp.nanosec * 1e-9;
+    const auto tf_time = to_tf_time(img_msg.header.stamp);
+
+    // Resolve the camera name up front (for the mosaic tile + per-camera counters).
+    std::string cam_name;
+    if (auto it = optical_to_cam.find(optical_frame); it != optical_to_cam.end()) {
+      cam_name = it->second;
+      ++seg_seen[cam_name];
+    }
+
+    // Decode + stash the display tile BEFORE the TF lookup: the mosaic should show
+    // each camera's imagery regardless of whether a pose is available for this
+    // exact stamp (a TF miss must not blank the tile — it only blocks projection).
+    cv::Mat mask;
+    try {
+      mask = cv_bridge::toCvCopy(img_msg, "rgb8")->image;
+    } catch (const cv_bridge::Exception &) { continue; }
+    if (!cam_name.empty()) {
+      cv::Mat bgr;
+      cv::cvtColor(mask, bgr, cv::COLOR_RGB2BGR);
+      latest_mask_bgr[cam_name] = bgr;
+    }
+
+    try {
+      // Camera pose in world + boat pose in world at the image stamp.
+      const auto cam_tf = tf_buffer.lookupTransform(kWorldFrame, optical_frame, tf_time);
+      const auto boat_tf = tf_buffer.lookupTransform(kWorldFrame, kBoatFrame, tf_time);
+
+      const auto & ct = cam_tf.transform.translation;
+      const auto & cq = cam_tf.transform.rotation;
+      const cv::Vec3d camera_origin(ct.x, ct.y, ct.z);
+      const cv::Matx33d rot =
+        sea_surface_segmentation::rotation_matrix_from_quaternion(cq.x, cq.y, cq.z, cq.w);
+
+      // Moving window: re-centre the buffer on the boat, decay, then ingest.
+      const double bx = boat_tf.transform.translation.x;
+      const double by = boat_tf.transform.translation.y;
+      buffer.move(grid_map::Position(bx, by));
+      buffer.decay(stamp_s);
+
+      // INVERSE (cell→pixel) projection — the corrected path; fills each pixel's footprint.
+      for (const auto & o : project_observations_inverse(
+          mask, model_it->second, camera_origin, rot, max_range, bx, by, res, half_extent, 0.0))
+      {
+        const grid_map::Position p(o.x, o.y);
+        if (o.obstacle) { buffer.hit(p); } else { buffer.miss(p); }
+        if (!cam_name.empty()) { ++obs_inv_cells[cam_name]; }
+      }
+      ++processed;
+
+      // Render the mosaic at the requested cadence.
+      if (last_render < 0.0 || stamp_s - last_render >= render_dt) {
+        last_render = stamp_s;
+        cv::Mat canvas(canvas_h, canvas_w, CV_8UC3, cv::Scalar(20, 20, 20));
+
+        // --- Top row: camera tiles, port | fwd | stbd | aft. ---
+        for (int k = 0; k < 4; ++k) {
+          const std::string cam = cam_order[k];
+          const int x = k * cam_w;
+          auto it = latest_mask_bgr.find(cam);
+          cv::Mat tile;
+          if (it != latest_mask_bgr.end()) {
+            cv::resize(it->second, tile, cv::Size(cam_w, cam_h), 0, 0, cv::INTER_NEAREST);
+          } else {
+            tile = cv::Mat(cam_h, cam_w, CV_8UC3, cv::Scalar(0, 0, 0));
+          }
+          tile.copyTo(canvas(cv::Rect(x, cam_row_y, cam_w, cam_h)));
+          label(canvas, cam.substr(4), {x + 4, header_px - 6}, 0.45);  // drop "oak_"
+        }
+        char tlabel[48];
+        std::snprintf(tlabel, sizeof(tlabel), "t=%.1fs", stamp_s);
+        label(canvas, tlabel, {canvas_w - 110, header_px - 6}, 0.45);
+
+        // --- Bottom row: LIVE costmap | OURS (inverse, corrected). --- (boat-centred, N-up)
+        cv::Mat live = render_live(live_costmap, have_costmap, bx, by, panel_px, res);
+        cv::circle(live, {panel_px / 2, panel_px / 2}, 4, {0, 255, 255}, -1);
+        live.copyTo(canvas(cv::Rect(0, cm_row_y, panel_px, panel_px)));
+
+        cv::Mat ours = render_new(buffer, bx, by, panel_px, res, params.lethal_threshold);
+        cv::circle(ours, {panel_px / 2, panel_px / 2}, 4, {0, 255, 255}, -1);
+        ours.copyTo(canvas(cv::Rect(panel_px, cm_row_y, panel_px, panel_px)));
+
+        // --- Costmap row labels. ---
+        label(canvas, "LIVE costmap (boat)", {6, cm_label_y + 16}, 0.5);
+        char nhdr[80];
+        std::snprintf(nhdr, sizeof(nhdr), "OURS - inverse  win=%.0fm", window_m);
+        label(canvas, nhdr, {panel_px + 6, cm_label_y + 16}, 0.5);
+
+        char path[512];
+        std::snprintf(path, sizeof(path), "%s/frame_%05d.png", out_dir.c_str(), frame_idx++);
+        cv::imwrite(path, canvas);
+      }
+    } catch (const tf2::TransformException &) {
+      // TF not available for this stamp — projection skipped (tile already shown).
+      if (!cam_name.empty()) { ++tf_fail[cam_name]; }
+      continue;
+    }
+  }
+
+  std::fprintf(stderr, "done: %ld segmentation frames processed, %d mosaic frames in %s\n",
+    processed, frame_idx, out_dir.c_str());
+  std::fprintf(stderr, "per-camera (inverse path): seg_seen / tf_fail / cells_fed_to_buffer\n");
+  for (const auto * cam : kCameras) {
+    std::fprintf(stderr, "  %-14s %6ld / %6ld / %10ld%s\n", cam,
+      seg_seen[cam], tf_fail[cam], obs_inv_cells[cam],
+      seg_seen[cam] > 0 && tf_fail[cam] == seg_seen[cam] ? "   <-- ALL TF FAILED" : "");
+  }
+  std::fprintf(stderr,
+    "assemble: ffmpeg -framerate 10 -i %s/frame_%%05d.png -pix_fmt yuv420p %s/mosaic.mp4\n",
+    out_dir.c_str(), out_dir.c_str());
+  return 0;
+}

--- a/sea_surface_segmentation/tools/bag_to_costmap_video.cpp
+++ b/sea_surface_segmentation/tools/bag_to_costmap_video.cpp
@@ -158,65 +158,8 @@ cv::Mat render_live(const nav_msgs::msg::OccupancyGrid & grid, bool have_grid,
   return panel;
 }
 
-// PROTOTYPE — inverse (ground-up) projection, for A/B comparison against the
-// forward `project_observations`. Instead of mapping each image pixel to one cell,
-// it iterates the world cells in the boat-centred window and asks "which pixel
-// covers this cell?", so a single large/distant pixel fills EVERY cell in its
-// footprint (no gaps) and the search is naturally range-bounded to the window
-// (a near-horizon pixel can't smear past the window edge). Same contact-only
-// classification as the forward path: a cell that projects to its column's
-// waterline-contact pixel → obstacle; to water → free; to an above-contact body
-// pixel → skipped (occluded/unknown). Lives in the tool, not the shared header —
-// this is a comparison probe, not (yet) the layer's path.
-std::vector<sea_surface_segmentation::OccupancyObservation> project_observations_inverse(
-  const cv::Mat & mask, const image_geometry::PinholeCameraModel & cam,
-  const cv::Vec3d & cam_origin, const cv::Matx33d & rot_cam_to_world,
-  double max_range, double bx, double by, double res, double half_extent, double plane_z = 0.0)
-{
-  // Lowest (nearest) waterline contact per column — same primitive as forward.
-  std::vector<int> contact_row(mask.cols, -1);
-  for (int col = 0; col < mask.cols; ++col) {
-    for (int row = mask.rows - 1; row >= 0; --row) {
-      if (sea_surface_segmentation::is_waterline_contact_pixel(mask, row, col)) {
-        contact_row[col] = row;
-        break;
-      }
-    }
-  }
-
-  const cv::Matx33d rot_world_to_cam = rot_cam_to_world.t();
-  std::vector<sea_surface_segmentation::OccupancyObservation> obs;
-  const int n = static_cast<int>(std::lround(2.0 * half_extent / res));
-  for (int iy = 0; iy < n; ++iy) {
-    for (int ix = 0; ix < n; ++ix) {
-      const double wx = bx + (ix - n / 2) * res;
-      const double wy = by + (iy - n / 2) * res;
-      const cv::Vec3d d(wx - cam_origin[0], wy - cam_origin[1], plane_z - cam_origin[2]);
-      if (std::sqrt(d.dot(d)) > max_range) { continue; }     // beyond sensor range
-      const cv::Vec3d pc = rot_world_to_cam * d;             // cell in camera optical frame
-      if (pc[2] <= 0.0) { continue; }                        // behind the camera
-      const cv::Point2d uv = cam.project3dToPixel(cv::Point3d(pc[0], pc[1], pc[2]));
-      const int u = static_cast<int>(std::lround(uv.x));
-      const int v = static_cast<int>(std::lround(uv.y));
-      if (u < 0 || u >= mask.cols || v < 0 || v >= mask.rows) { continue; }
-      const cv::Vec3b px = mask.at<cv::Vec3b>(v, u);
-      // Class channels (rgb8): R=obstacle prob, G=water prob, B=sky prob.
-      // Only positively-observed water marks the cell free; sky/ambiguous → skip
-      // (a ground cell on z=0 sampling a sky pixel is a geometric inconsistency,
-      // and clearing on it would erase legitimate hits from other frames/cameras).
-      if (sea_surface_segmentation::is_obstacle_pixel(px)) {
-        if (contact_row[u] >= 0 && v >= contact_row[u]) {
-          obs.push_back({wx, wy, true});                     // waterline contact → hit
-        }
-        // else: above the contact = occluded body → unobserved
-      } else if (px[1] > px[0] && px[1] > px[2]) {           // green-dominant = water
-        obs.push_back({wx, wy, false});                      // positively observed water → miss
-      }
-      // else: sky (blue-dominant) or ambiguous → skip (no observation)
-    }
-  }
-  return obs;
-}
+// (Inverse projection lives in segments_projection.hpp now — the layer and this
+// tool share one source of truth, see `project_observations_inverse`.)
 
 void label(cv::Mat & img, const std::string & text, cv::Point org, double scale = 0.5)
 {
@@ -409,8 +352,11 @@ int main(int argc, char ** argv)
       buffer.decay(stamp_s);
 
       // INVERSE (cell→pixel) projection — the corrected path; fills each pixel's footprint.
-      for (const auto & o : project_observations_inverse(
-          mask, model_it->second, camera_origin, rot, max_range, bx, by, res, half_extent, 0.0))
+      // Tool centres iteration on the boat (visualisation window); the live layer
+      // centres on the camera. Either is valid — the helper iterates a square AABB.
+      for (const auto & o : sea_surface_segmentation::project_observations_inverse(
+          mask, model_it->second, camera_origin, rot, max_range,
+          bx, by, res, half_extent, 0.0))
       {
         const grid_map::Position p(o.x, o.y);
         if (o.obstacle) { buffer.hit(p); } else { buffer.miss(p); }


### PR DESCRIPTION
Part of #19 (capability only — does **not** auto-close it; the dependent seafloor config-migration PR finalizes #19 once the multi-source handoff is verified, per the plan).

# Plan: Re-architect SeaSurfaceLayer as a single multi-camera fused occupancy layer (temporal persistence + decay)

## Issue

https://github.com/rolker/unh_marine_perception/issues/19

_Revised 2026-05-27 per review-plan (`c72005e`, changes-requested) and follow-up design calls:
log-odds buffer backed by **grid_map** (resolves the float-buffer rolling risk via `GridMap::move()`);
#10 H tide-drift confirmed a **non-issue for a floating platform** and dropped._

## Context

Today: four independent `SeaSurfaceLayer` instances (forward/port/starboard/aft), each with a
private buffer that `segmentsCallback` wipes (`resetMapToValue` line 159) every frame and re-marks
only the current FOV. Consequences proven on the 2026-05-26 bag: no obstacle memory (forgotten the
instant it leaves the FOV — the small-buoy resume), ~50% of dynamic marks flicker even with FOV held
fixed, and tall obstacles smear false "shadow" lethal cells (above-waterline pixels back-projected
onto the water plane land far beyond the real obstacle). Per-camera buffers will break the FOV handoff
once persistence is added. Overlaps #10 items D, I, E/F, L (H is resolved as a non-issue — see phase 3).

A tested `is_waterline_contact_pixel` helper + the marking rule already landed (`fe337f6`) against the
old architecture; the helper/tests carry forward, the integration moves into the rewrite below.

## Approach

Phased, atomic commits. The layer becomes **multi-source-capable but back-compatible with a single
source**, so this perception PR can land and be reviewed without the config flip. Per review-plan
(`c72005e`): **this perception PR is _Part of_ #19** (delivers the capability); the dependent seafloor
config-migration PR activates cross-camera fusion, verifies the handoff AC on bag/sim, and **finalizes
#19**. *Per-phase invariant:* every commit leaves the layer buildable AND single-source-correct.

1. **Roll the persistent buffer instead of wiping it (#10 D), via grid_map** — stop the
   `matchSize()`-on-every-shift wipe. Back the log-odds buffer with a **`grid_map::GridMap`** float
   layer and roll it with `GridMap::move()`, which shifts by circular-buffer index (no copy), clears
   only newly-exposed cells, and carries a sub-cell offset so **fractional-meter origin steps** are
   handled correctly — exactly the rolling-window case `Costmap2D::updateOrigin()` (uint8-only) can't
   serve. Sync the grid_map position to the master costmap's rolling origin each cycle. Load-bearing
   prerequisite; addresses #10 D. Test: evidence survives a *sequence* of sub-cell origin shifts and
   lands in the correct world cell. (Also revisit `isClearable()` — hard-coded `false` today — now that
   the layer clears via decay.)
2. **Log-odds occupancy logic** — the buffer is a grid_map float layer (`log_odds`), optionally with a
   `last_update` layer for time-based decay. Keep the update math (hit/miss, decay toward prior,
   threshold→LETHAL) in a **pure, unit-tested** helper (`occupancy_buffer.hpp`, mirroring the
   `segments_apply.hpp` pure-logic + test pattern) operating on the layer data — grid_map owns storage
   and rolling, the helper owns the evidence math.
3. **Inverted projection + waterline-contact + occlusion (#10 I; shadow)** — per segmentation frame,
   scan image columns for the waterline contact (`is_waterline_contact_pixel`) and back-project **only
   the contact** onto the water surface (z=0 in `map_tide`) → `hit`; raytrace the free cells between the
   camera and the contact → `miss` (clearing); leave the occluded region beyond the contact unobserved
   (decays, never marked). Needs a **new** pure helper (contact-only projection + camera→contact
   free-space raytrace) — `project_obstacle_pixels` emits points for *all* obstacle pixels and is the
   wrong primitive; it stays unchanged for its other consumer `segments_to_pointcloud.cpp` (reflex feed),
   confirmed unaffected. Folds in `fe337f6`; addresses #10 I. **z=0 is correct here**: the boat floats
   and `map_tide` z=0 tracks the water surface, so projecting onto z=0 *is* projecting onto the real
   surface at any tide — #10 H's vertical-drift worry does not apply to a floating platform (residuals:
   TF stamp consistency, already handled via `lookupTransform` at the image stamp; wave heave, a small
   transient handled by `base_link_level`). Note this on #10. *Quantization:* on the 128×96 mask,
   contact-range uncertainty is range-dependent (one pixel-row ≈ meters near max range), so
   decay/threshold defaults must tolerate a contact jittering across a few cells without re-creating
   flicker — covered by a tuning note + test.
4. **Multi-source subscriptions (consolidate 4→1)** — accept a list of camera sources (segmentation +
   camera_info + per-source `maximum_range`); all feed the one shared world-frame buffer (so an obstacle
   reinforces the same cell across cameras — the handoff fix). A single source remains valid (back-compat).
5. **Thread-safety (#10 E/F)** — guard the shared buffer and per-source camera models against the N
   concurrent camera/camera_info callbacks; fix the `camera_model_` / `count_x_` races.
6. **Live-tunable parameters via a param callback (#10 K)** — register an `OnSetParametersCallbackHandle`
   so the tuning scalars change at runtime (`ros2 param set`) without a stack restart, for on-water
   tuning: **decay half-life, hit/miss log-odds increments, lethal threshold, per-source max range**.
   The callback **validates** inputs (reject NaN/negative/out-of-range → `successful=false`) so a
   fat-fingered set can't silently poison the buffer interpretation, applies under the buffer lock
   without re-taking it (a new threshold reinterprets the accumulated buffer immediately; new
   decay/increments take effect next update). Source list / topics stay configure-time. A test asserts
   the callback applies valid changes AND rejects invalid ones (the current layer silently ignores
   runtime params — the #10-K failure mode).
7. **Tests (#10 L)** — occupancy buffer (hit raises / miss+decay lowers / threshold / decays to prior
   over time / **evidence survives a sequence of fractional-meter `grid_map::move()` shifts**),
   waterline-contact + free-space-miss + occlusion, two-source fusion reinforcing one world cell, param
   validate+apply.
8. **Docs + config follow-up (this is what finalizes #19)** — document new params; the dependent seafloor
   `nav2_params.yaml` migration (4 blocks → 1 multi-source) **is the PR that finalizes #19**, since it
   activates cross-camera fusion and is where the handoff AC is verified (bag/sim). Note IzzyBoat parity.

## Files to Change

| File | Change |
|------|--------|
| `sea_surface_segmentation/src/sea_surface_layer.cpp` | Rewrite: multi-source subs, shared log-odds buffer as a `grid_map` float layer rolled via `move()` and converted to the master via `grid_map_costmap_2d`, inverted projection w/ waterline-contact + free-space-miss + occlusion, decay, thread-safe, validating param callback, `isClearable()` revisit |
| `sea_surface_segmentation/src/occupancy_buffer.hpp` | New pure log-odds update math (hit/miss/decay/threshold) over a grid_map layer; grid_map owns storage + rolling |
| `sea_surface_segmentation/src/segments_projection.hpp` | `is_waterline_contact_pixel` (done) + **new** contact-only / free-space-miss projection helper; do NOT repurpose `project_obstacle_pixels` (shared with `segments_to_pointcloud.cpp`) |
| `sea_surface_segmentation/package.xml` | Add deps: `grid_map_core`, `grid_map_ros`, `grid_map_costmap_2d` (rosdep-resolvable; already a workspace dep via camp) |
| `sea_surface_segmentation/test/test_occupancy_buffer.cpp` | New: log-odds + decay + `grid_map::move()` fractional-shift persistence tests |
| `sea_surface_segmentation/test/test_segments_projection.cpp` | Waterline tests (done) + contact/miss/occlusion + fusion cases |
| `sea_surface_segmentation/CMakeLists.txt` | `find_package(grid_map_*)` + link; register new test |
| `sea_surface_segmentation/README*` / params doc | Document sources, decay, thresholds, runtime-tunable params |
| seafloor `echoboat_project11/config/nav2_params.yaml` *(follow-up PR — finalizes #19)* | 4 instances → 1 multi-source block (local_costmap only; global_costmap doesn't use the layer) |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Improve incrementally | Phased atomic commits, each buildable + single-source-correct; phase 1 (grid_map buffer + rolling) is independently splittable |
| A change includes its consequences | Tests, param docs, shared-header consumer check, new dependency, and config migration tracked |
| Test what breaks | Fractional-shift persistence, decay, fusion, flicker rejection, concurrency, param validate/apply |
| Only what's needed | Log-odds justified by the noise data; **grid_map reused** (already a workspace dep) rather than hand-rolling buffer rolling math |
| Human control & transparency | Tuning scalars live-tunable (validated) at runtime; decay model decided (log-odds) |
| Capture decisions | Plan + PR record rationale; #10 flagged this as ADR-like (no project ADR mechanism → captured here) |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0008 — ROS 2 conventions | Yes | nav2 multi-source idiom + validating `OnSetParametersCallbackHandle`; buffer rolling via `grid_map::move()` (idiomatic float-grid primitive) + `grid_map_costmap_2d` bridge; target Rolling; no deviation needing its own ADR |
| 0001 — Adopt ADRs | Watch | Design rationale + decay-model decision captured in plan/PR (no project-level ADR mechanism in this repo) |
| 0002 — Worktree isolation | Yes | Work on `feature/issue-19` layer worktree |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| `SeaSurfaceLayer` params/behavior | seafloor `nav2_params.yaml` (4→1 multi-source, local_costmap only) | Follow-up PR — **finalizes #19** |
| ... | IzzyBoat config parity (#120/#181) | Noted for follow-up |
| Add `grid_map` dependency | `package.xml` + `CMakeLists.txt` (rosdep-resolvable; camp precedent) | Yes |
| `segments_projection.hpp` (shared header) | confirm `segments_to_pointcloud.cpp` (reflex feed) unaffected by the new helper | Yes |
| The layer | package README / param docs | Yes |
| Layer logic | regression tests (#10 L) | Yes |
| (reconcile #10) | D, I, E/F, L addressed; **H = non-issue for a floating platform** (note on #10, no code change) | Note in PR + comment on #10 |

## Open Questions

- **Decay model — DECIDED: log-odds** (2026-05-27). Tuning scalars live-reconfigurable (phase 6).
- **#19 closure / sequencing — DECIDED** (2026-05-27, review-plan): this perception PR is _Part of_ #19
  (capability); the seafloor config PR activates fusion, verifies the handoff, and finalizes #19.
- **#10 H tide z-drift — RESOLVED** (2026-05-27): non-issue for a floating boat (z=0 = water surface,
  tracked by `map_tide`); no `plane_z` work needed; leave a note on #10.
- **Default tuning** — decay half-life, hit/miss increments, lethal threshold: propose conservative
  defaults, tune on water (non-blocking).

## Estimated Scope

This perception PR (atomic commits per phase, each buildable + single-source-correct) + a dependent
`seafloor_echoboat_project11` config PR that **finalizes #19**. Phase 1 (grid_map-backed log-odds buffer
+ `move()`-rolling + fractional-shift test) is the core, independently reviewable piece — de-risked by
leaning on grid_map rather than hand-rolled buffer math. If the single perception PR proves unwieldy in
review, split phase 1 out first. Bookkeeping handled here; no per-ticket overhead for the user.
