### PR TITLE
sea_surface marking + costmap dynamics: accumulate per-pixel softmax log-odds (drop the argmax gate), graded cost ramp, bounded recovery

### DIFF
--- a/.agent/work-plans/issue-22/plan.md
+++ b/.agent/work-plans/issue-22/plan.md
@@ -99,10 +99,17 @@ predicates — the reflex Collision-Monitor path is known-good and out of scope.
 
 ## Open Questions
 
-- **Planner cost weighting (separate repo)** — the graded ramp only biases routing
-  if `SmacPlannerHybrid.cost_penalty` / MPPI `CostCritic` are tuned in the
-  echoboats/seafloor nav2 config. Until then the gradient is visible (rviz) and the
-  controller may honor it, but global routing won't. Follow-up config task.
+- **Planner cost weighting (already wired — tune, don't enable)** — verified
+  against `seafloor_echoboat_project11/.../nav2_params.base.yaml`: the global
+  `SmacPlannerHybrid` already has `cost_penalty: 10.0`, so the relayed graded
+  gradient **does** bias global routing today (no config change needed to
+  activate). The controller is `CrabbingPathFollower` (PID path tracker) which
+  ignores costmap cost entirely — so avoidance is planner-side + the reflex
+  Collision Monitor, not the controller. Real follow-up is *tuning*: (1)
+  `cost_penalty: 10` is aggressive and may deflect routes around low-confidence
+  soft cells; (2) `inflation_radius: 150` m means every now-lethal cell (incl.
+  newly-marking weak buoys) creates a 150 m standoff bubble — validate routing
+  isn't over-conservative in a buoy field.
 - **On-water tuning** — defaults (`obstacle_prob_min=0.35`, `max_evidence_step=0.85`,
   `clear_floor=−2`, `free_threshold=0`, `lethal_threshold=1`) are provisional; all
   are runtime-reconfigurable. Tune `obstacle_prob_min` first (dim-buoy sensitivity)
@@ -112,8 +119,9 @@ predicates — the reflex Collision-Monitor path is known-good and out of scope.
 
 ## Estimated Scope
 
-Single PR (#25), implemented. Follow-up: planner-side cost-weight config in the
-echoboats/seafloor nav2 repo to activate soft-cost routing.
+Single PR (#25), implemented. Follow-up: on-water tuning of `cost_penalty` /
+`inflation_radius` vs. the new gradient in the echoboats/seafloor nav2 config
+(tuning, not enabling — routing already honors costs).
 
 ## Implementation Notes
 

--- a/.agent/work-plans/issue-22/plan.md
+++ b/.agent/work-plans/issue-22/plan.md
@@ -15,60 +15,71 @@ into the log-odds buffer. Marginal-red obstacles are scored as confident water a
 symmetric ±5 clamp over-damps recovery once a cell has saturated to water.
 
 Fix: stop collapsing the softmax. Feed the buffer the real per-pixel occupancy
-log-odds `Δ = clamp(log(R/(255−R)))`, bound recovery with an asymmetric clamp, and
-(phase 2) emit a graded cost ramp instead of binary lethal.
+log-odds (prior-shifted at `obstacle_prob_min`; see Implementation Notes), bound
+recovery with an asymmetric clamp, and emit a graded cost ramp instead of binary
+lethal. Single PR; all knobs runtime-tunable.
 
-## Approach
+## Approach (single PR — implemented)
 
-**Phase 1 — graded evidence + bounded recovery (safety/correctness, PR1)**
+Per the 2026-05-29 discussion: **one PR**, **graded cost output** (not binary),
+**all knobs runtime-tunable** for on-water tuning, and the **reflex/Collision-Monitor
+path left untouched** (it is known-good; the #186 bug is costmap-only).
 
-1. **`OccupancyObservation` carries evidence** — add a `double log_odds` field
-   (keep `bool obstacle` for back-compat with the #23 offline core). Additive only.
-2. **Compute per-pixel log-odds** in `project_observations_inverse` (and forward
-   `project_observations`): for the waterline-contact and water cells, set
-   `log_odds = clamp(log((R+ε)/(255−R+ε)))` with ε guarding `R∈{0,255}` → ±∞.
-   Drop the argmax-only classification as the vote source.
-3. **Buffer applies the increment** — `OccupancyBuffer::apply(pos, obs.log_odds)`
-   instead of fixed hit/miss; `sea_surface_layer.cpp:408–414` passes it through.
-4. **Asymmetric clamp** — split `clamp` into `obstacle_ceiling` (+5) and
-   `clear_floor` (−2) in `OccupancyParams` + `validate()`; recovery cleared→lethal
-   drops ~8→~4 frames.
-5. **Reflex-gate consistency** — `segments_to_pointcloud` (reflex feed) thresholds
-   `P(obs) = R/255 > τ` instead of strict argmax, so faint obstacles reach the live
-   Collision Monitor too.
-6. **Tests** — `test_occupancy_buffer` (asymmetric clamp, increment apply, tail
-   clamp); `test_segments_projection` (log-odds at known RGB, ε guard, water
-   negative).
+1. **Graded per-observation evidence** — `OccupancyObservation` gains a signed
+   `double log_odds` (additive; keeps `obstacle` for the #23 shared API). A new
+   `pixel_log_odds(R, obstacle_prob_min, max_evidence_step)` returns a
+   **prior-shifted, capped logit** of the red channel:
+   `clamp(log((R+ε)/(255−R+ε)) − log(prob_min/(1−prob_min)), ±max_step)`.
+   The prior shift puts the zero-crossing at `obstacle_prob_min` (not 0.5), so a
+   buoy where water is marginally more likely (`P_obs > prob_min`) still banks
+   **positive** evidence — the actual #186 fix. Defaults: R=200→+0.85, R=120→+0.50,
+   R=20→−0.85.
+2. **Graded gate (costmap path only)** — `project_observations_inverse` replaces
+   the argmax `is_obstacle_pixel`/`is_waterline_contact_pixel` with
+   `is_obstacle_ish(px) = R ≥ obstacle_prob_min·255` (same waterline-contact
+   geometry), and emits `log_odds` for contact (+) and green-water (−) cells; sky
+   /ambiguous still skipped.
+3. **Buffer accumulates the signed increment** — `OccupancyBuffer::accumulate(pos,
+   log_odds)` (replaces `hit()/miss()`), clamped to **asymmetric**
+   `[clear_floor=−2, obstacle_clamp=+5]` (recovery cleared→lethal ~8→~4 frames).
+4. **Graded occupancy + cost** — `occupancyAt()` maps log-odds to `−1` (no opinion:
+   unobserved or ≤`free_threshold`) / `1…99` ramp / `100` (≥`lethal_threshold`).
+   New `cost_mapping.hpp::occupancy_to_cost()` maps that to nav2 cost: `−1`
+   (untouched) / soft `1…252` / `LETHAL=254` (stays below `INSCRIBED=253`).
+5. **Graded output everywhere** — layer `updateCosts` stamps the ramp; the layer
+   publishes the graded occupancy grid; `SeaSurfaceRelayLayer` forwards the full
+   gradient (not just `≥100`). Both still only **ADD** (no-opinion never clears).
+6. **All params runtime-tunable** — `obstacle_prob_min`, `max_evidence_step`,
+   `obstacle_clamp`, `clear_floor`, `free_threshold`, `lethal_threshold`,
+   `decay_half_life_s` validate-then-apply via `onParametersSet`.
+7. **Tests** — buffer accumulate/`occupancyAt`/`validate`; `cost_mapping`
+   boundaries; graded accumulator expectations; projection log-odds signs.
+   **69 tests pass.**
 
-**Phase 2 — graded cost ramp + relay gradient (planning, PR2)**
-
-7. **Cost ramp** — map accumulated log-odds → cost in `updateCosts`:
-   `≤clear_thresh`→0, ramp `1…252`, `≥lethal_thresh`→254, NaN→untouched.
-8. **Relay full gradient** — `sea_surface_relay_layer.cpp` forwards the whole
-   `1…254` range, not only `≥100`.
-9. **Config + docs** — declare new params; update `config/README.md` + `config/`.
-10. **Tests** — ramp boundaries; relay carries intermediate costs.
-
-## Files to Change
+## Files Changed
 
 | File | Change |
 |------|--------|
-| `src/segments_projection.hpp` | `OccupancyObservation.log_odds`; compute `log(R/(255−R))` in both projections |
-| `src/occupancy_buffer.hpp` | apply arbitrary increment; asymmetric clamp params + `validate()`; (P2) `costAt()` ramp |
-| `src/sea_surface_layer.cpp` | pass `obs.log_odds` to buffer; (P2) emit cost ramp; param declarations |
-| `src/sea_surface_relay_layer.cpp` | (P2) forward full `1…254` gradient |
-| `src/segments_to_pointcloud.cpp` (+`-reflex`) | reflex gate `P(obs)>τ` |
-| `config/` + `config/README.md` | new params (`clear_floor`, `obstacle_ceiling`, `clear_thresh`, `lethal_thresh`, `reflex_tau`) |
-| `test/test_occupancy_buffer.cpp`, `test/test_segments_projection.cpp` | new cases above |
+| `include/.../segments_projection.hpp` | `OccupancyObservation.log_odds`; `pixel_log_odds()`; graded gate in `project_observations_inverse` (argmax predicates kept for the reflex/forward paths) |
+| `include/.../occupancy_buffer.hpp` | `accumulate()`; asymmetric clamp params; `occupancyAt()`; reworked `validate()`; snapshot ctor for off-lock publish |
+| `include/.../cost_mapping.hpp` (NEW) | `occupancy_to_cost()` — the one nav2-cost mapping, shared by layer + relay |
+| `include/.../occupancy_accumulator.hpp` | `AccumulateParams` gains `obstacle_prob_min`/`max_evidence_step`; uses `accumulate()` |
+| `src/sea_surface_layer.cpp` | new param block + live snapshot; graded `updateCosts`; graded publish; `onParametersSet` |
+| `src/sea_surface_relay_layer.cpp` | forward the full graded gradient via `occupancy_to_cost` |
+| `config/README.md` | param table + behavior for both layers |
+| `CMakeLists.txt`, `test/*` | `cost_mapping` link; updated/added tests |
+
+_Not changed (intentionally): `src/segments_to_pointcloud.cpp` and the argmax
+predicates — the reflex Collision-Monitor path is known-good and out of scope._
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
 | A change includes its consequences | Relay gradient, `OccupancyObservation` consumers (#23 offline core), config docs, tests all in plan |
-| Only what's needed | Two-timescale rebuild explicitly rejected (reflex monitor owns dynamics); graded output is P2, not gold-plating |
-| Test what breaks | Log-odds tails (±∞ guard), asymmetric clamp, ramp boundaries, water-negative all get unit tests |
-| Improve incrementally | Stacked PRs: P1 fixes the operator bug + safety; P2 adds planning gradient |
+| Only what's needed | Two-timescale rebuild rejected (reflex owns dynamics); reflex-gate change dropped (CA known-good); graded output kept (user wants varying cost) |
+| Test what breaks | Log-odds tails (ε guard), asymmetric clamp, ramp boundaries, water-negative, cost-mapping boundaries — all unit-tested (69 pass) |
+| Improve incrementally | Single PR by user direction (test window); knobs runtime-tunable so behavior is refined on-water rather than across PRs |
 
 ## ADR Compliance
 
@@ -83,22 +94,35 @@ log-odds `Δ = clamp(log(R/(255−R)))`, bound recovery with an asymmetric clamp
 | If we change... | Also update... | Included? |
 |---|---|---|
 | `OccupancyObservation` struct | #23 offline bag→costmap core (consumes it — PR #24 open) | Yes — additive field; coordinate sequencing |
-| flat hit/miss → increment | any test asserting fixed ±0.85/−0.40 | Yes — Phase 1 tests |
-| binary lethal → ramp | relay (`≥100`), global planner cost weights, inflation ordering | Yes — Phase 2 + tuning note |
+| flat hit/miss → increment | tests asserting fixed ±0.85/−0.40 | Yes — accumulator/buffer tests updated to graded values |
+| binary lethal → graded ramp | relay (was `≥100`), global planner cost weights, inflation ordering | Relay + layer emit the gradient; **planner `cost_penalty`/`CostCritic` live in the echoboats/seafloor nav2 config repo — soft costs are inert for routing until set there** (see Open Questions) |
 
 ## Open Questions
 
-- **PR split** — P1 (graded evidence + asymmetric clamp + reflex gate) then P2
-  (graded ramp + relay)? Or single PR? P1 alone fixes the #186 bug.
-- **Reflex `τ`** — safety call: how confident before a faint obstacle triggers a
-  Collision Monitor stop vs. only soft-biasing the route? (surface to user)
-- **Numeric defaults** — `clear_floor`, thresholds, `τ` are provisional pending the
-  #186-bag R-distribution tuning; ship defaults that preserve current behavior at
-  the margins, then tune.
-- **#23 coordination** — sequence the `OccupancyObservation` change relative to the
-  in-flight offline-core export (PR #24).
+- **Planner cost weighting (separate repo)** — the graded ramp only biases routing
+  if `SmacPlannerHybrid.cost_penalty` / MPPI `CostCritic` are tuned in the
+  echoboats/seafloor nav2 config. Until then the gradient is visible (rviz) and the
+  controller may honor it, but global routing won't. Follow-up config task.
+- **On-water tuning** — defaults (`obstacle_prob_min=0.35`, `max_evidence_step=0.85`,
+  `clear_floor=−2`, `free_threshold=0`, `lethal_threshold=1`) are provisional; all
+  are runtime-reconfigurable. Tune `obstacle_prob_min` first (dim-buoy sensitivity)
+  against the #186 bag / live segmentation.
+- **#23 coordination** — `OccupancyObservation` gained a field (additive); coordinate
+  with the in-flight offline-core export (PR #24) on merge order.
 
 ## Estimated Scope
 
-Two stacked PRs (P1 safety/correctness, P2 planning gradient). P1 ~moderate; P2
-touches relay + planner tuning.
+Single PR (#25), implemented. Follow-up: planner-side cost-weight config in the
+echoboats/seafloor nav2 repo to activate soft-cost routing.
+
+## Implementation Notes
+
+- **Prior-shifted logit, not plain `log(R/(255−R))`.** The original plan/issue used
+  the unshifted logit (zero-crossing at P=0.5). That would still drop a buoy whose
+  pixels are red-present-but-water-dominant (`G > R`, i.e. `P_obs < 0.5`) — the
+  exact #186 case. Shifting the zero-crossing to `obstacle_prob_min` lets such
+  pixels bank positive evidence, and makes `obstacle_prob_min` the headline
+  on-water sensitivity knob. `max_evidence_step` caps a single frame (flicker
+  rejection; ~2 frames to lethal at defaults).
+- **Off-lock graded publish** uses a read-only `OccupancyBuffer` snapshot ctor so
+  `occupancyAt` remains the single source of the ramp (no duplicate mapping).

--- a/.agent/work-plans/issue-22/plan.md
+++ b/.agent/work-plans/issue-22/plan.md
@@ -1,0 +1,104 @@
+# Plan: sea_surface marking + costmap dynamics — accumulate per-pixel softmax log-odds
+
+## Issue
+
+https://github.com/rolker/unh_marine_perception/issues/22
+
+## Context
+
+The segmentation mask is a per-pixel **softmax** scaled to 255
+(`sea_surface_segmentation.cpp:124–131`): `R=255·P(obstacle)`, `G=255·P(water)`,
+`B=255·P(sky)`, `R+G+B=255`. The costmap discards this graded confidence: a strict
+argmax gate (`segments_projection.hpp:44`) feeds a flat `hit(+0.85)`/`miss(−0.40)`
+into the log-odds buffer. Marginal-red obstacles are scored as confident water and
+*erode* accumulated evidence (never register — the #186 operator bug), and the
+symmetric ±5 clamp over-damps recovery once a cell has saturated to water.
+
+Fix: stop collapsing the softmax. Feed the buffer the real per-pixel occupancy
+log-odds `Δ = clamp(log(R/(255−R)))`, bound recovery with an asymmetric clamp, and
+(phase 2) emit a graded cost ramp instead of binary lethal.
+
+## Approach
+
+**Phase 1 — graded evidence + bounded recovery (safety/correctness, PR1)**
+
+1. **`OccupancyObservation` carries evidence** — add a `double log_odds` field
+   (keep `bool obstacle` for back-compat with the #23 offline core). Additive only.
+2. **Compute per-pixel log-odds** in `project_observations_inverse` (and forward
+   `project_observations`): for the waterline-contact and water cells, set
+   `log_odds = clamp(log((R+ε)/(255−R+ε)))` with ε guarding `R∈{0,255}` → ±∞.
+   Drop the argmax-only classification as the vote source.
+3. **Buffer applies the increment** — `OccupancyBuffer::apply(pos, obs.log_odds)`
+   instead of fixed hit/miss; `sea_surface_layer.cpp:408–414` passes it through.
+4. **Asymmetric clamp** — split `clamp` into `obstacle_ceiling` (+5) and
+   `clear_floor` (−2) in `OccupancyParams` + `validate()`; recovery cleared→lethal
+   drops ~8→~4 frames.
+5. **Reflex-gate consistency** — `segments_to_pointcloud` (reflex feed) thresholds
+   `P(obs) = R/255 > τ` instead of strict argmax, so faint obstacles reach the live
+   Collision Monitor too.
+6. **Tests** — `test_occupancy_buffer` (asymmetric clamp, increment apply, tail
+   clamp); `test_segments_projection` (log-odds at known RGB, ε guard, water
+   negative).
+
+**Phase 2 — graded cost ramp + relay gradient (planning, PR2)**
+
+7. **Cost ramp** — map accumulated log-odds → cost in `updateCosts`:
+   `≤clear_thresh`→0, ramp `1…252`, `≥lethal_thresh`→254, NaN→untouched.
+8. **Relay full gradient** — `sea_surface_relay_layer.cpp` forwards the whole
+   `1…254` range, not only `≥100`.
+9. **Config + docs** — declare new params; update `config/README.md` + `config/`.
+10. **Tests** — ramp boundaries; relay carries intermediate costs.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/segments_projection.hpp` | `OccupancyObservation.log_odds`; compute `log(R/(255−R))` in both projections |
+| `src/occupancy_buffer.hpp` | apply arbitrary increment; asymmetric clamp params + `validate()`; (P2) `costAt()` ramp |
+| `src/sea_surface_layer.cpp` | pass `obs.log_odds` to buffer; (P2) emit cost ramp; param declarations |
+| `src/sea_surface_relay_layer.cpp` | (P2) forward full `1…254` gradient |
+| `src/segments_to_pointcloud.cpp` (+`-reflex`) | reflex gate `P(obs)>τ` |
+| `config/` + `config/README.md` | new params (`clear_floor`, `obstacle_ceiling`, `clear_thresh`, `lethal_thresh`, `reflex_tau`) |
+| `test/test_occupancy_buffer.cpp`, `test/test_segments_projection.cpp` | new cases above |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Relay gradient, `OccupancyObservation` consumers (#23 offline core), config docs, tests all in plan |
+| Only what's needed | Two-timescale rebuild explicitly rejected (reflex monitor owns dynamics); graded output is P2, not gold-plating |
+| Test what breaks | Log-odds tails (±∞ guard), asymmetric clamp, ramp boundaries, water-negative all get unit tests |
+| Improve incrementally | Stacked PRs: P1 fixes the operator bug + safety; P2 adds planning gradient |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0008 ROS2 conventions | Yes | New params declared/validated; costmap value semantics (252 vs 253 inscribed / 254 lethal) respected |
+| 0013 progress.md vocabulary | Yes | Plan-authored entry appended |
+| 0011 field mode | No | Repo origin is github.com (dev mode) |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| `OccupancyObservation` struct | #23 offline bag→costmap core (consumes it — PR #24 open) | Yes — additive field; coordinate sequencing |
+| flat hit/miss → increment | any test asserting fixed ±0.85/−0.40 | Yes — Phase 1 tests |
+| binary lethal → ramp | relay (`≥100`), global planner cost weights, inflation ordering | Yes — Phase 2 + tuning note |
+
+## Open Questions
+
+- **PR split** — P1 (graded evidence + asymmetric clamp + reflex gate) then P2
+  (graded ramp + relay)? Or single PR? P1 alone fixes the #186 bug.
+- **Reflex `τ`** — safety call: how confident before a faint obstacle triggers a
+  Collision Monitor stop vs. only soft-biasing the route? (surface to user)
+- **Numeric defaults** — `clear_floor`, thresholds, `τ` are provisional pending the
+  #186-bag R-distribution tuning; ship defaults that preserve current behavior at
+  the margins, then tune.
+- **#23 coordination** — sequence the `OccupancyObservation` change relative to the
+  in-flight offline-core export (PR #24).
+
+## Estimated Scope
+
+Two stacked PRs (P1 safety/correctness, P2 planning gradient). P1 ~moderate; P2
+touches relay + planner tuning.

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -53,3 +53,8 @@ layer and relay; all params runtime-reconfigurable. Reflex/CA path untouched. Ne
 - [ ] (suggestion) cost ramp is coarse at the low end (occ=1→1, 2→4) — monotonic, below INSCRIBED; no action _(Claude)_
 
 Static analysis: cpplint flags are pre-existing house style (passes repo pre-commit). Cross-model adversarial agreed on the init-validation gap; Copilot uniquely caught the cost-downgrade regression.
+
+### Copilot PR review (post-ready) — addressed
+- [x] (defensive) `pixel_log_odds` could UB/NaN on bad params in the exported header (shared with #23 tuner) — guard params, clamp R — `segments_projection.hpp:34`
+- [x] (defensive) `accumulate()` would store a NaN increment (drops evidence) — treat non-finite as no-op — `occupancy_buffer.hpp:66`
+- Both hardened + unit-tested (71 tests). Corrected the plan's "routing inert until config" note: verified `SmacPlannerHybrid.cost_penalty: 10.0` is already set in `seafloor_echoboat_project11` — routing honors the gradient today; controller (`CrabbingPathFollower`) ignores cost. Follow-up is tuning `cost_penalty`/`inflation_radius`, not enabling.

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -14,7 +14,23 @@ issue: 22
 **Phases**: 2 stacked PRs (P1 graded evidence + asymmetric clamp + reflex gate; P2 graded cost ramp + relay gradient)
 
 ### Open questions
-- [ ] PR split: P1 (graded evidence + asymmetric clamp + reflex gate) then P2 (graded ramp + relay), or single PR? P1 alone fixes the #186 bug.
-- [ ] Reflex `τ` safety call — confidence before a faint obstacle triggers a Collision Monitor stop vs. only soft-biasing the route (surface to user).
-- [ ] Numeric defaults (`clear_floor`, thresholds, `τ`) provisional pending #186-bag R-distribution tuning.
-- [ ] Coordinate the `OccupancyObservation` struct change with the in-flight offline-core export (#23 / PR #24).
+- [x] PR split → **single PR** (user direction, test window).
+- [x] Reflex `τ` → **dropped**; CA/Collision-Monitor path left untouched (known-good, #186 bug is costmap-only).
+- [ ] Numeric defaults provisional; all runtime-tunable — tune `obstacle_prob_min` first against the #186 bag / live segmentation.
+- [ ] Coordinate the `OccupancyObservation` additive field with the in-flight offline-core export (#23 / PR #24).
+- [ ] Planner-side `cost_penalty`/`CostCritic` config in the echoboats/seafloor nav2 repo to activate soft-cost routing (graded cost is inert for global routing until set).
+
+## Implementation
+**Status**: complete (build clean, 69 tests pass)
+**When**: 2026-05-29 11:06 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+Graded softmax log-odds + graded cost ramp landed on `feature/issue-22`. Per-observation
+evidence = prior-shifted capped logit of R (zero-crossing at `obstacle_prob_min`), asymmetric
+accumulator clamp, `occupancyAt`→`occupancy_to_cost` ramp (−1 / 1..252 / LETHAL) in both the
+layer and relay; all params runtime-reconfigurable. Reflex/CA path untouched. New
+`cost_mapping.hpp`. Worked defaults: R=200→+0.85, R=120→+0.50, R=20→−0.85.
+
+### Next
+- [ ] `/review-code` (pre-push) + Copilot review before merge.
+- [ ] On-water tune; activate planner cost weighting (separate config repo).

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -1,0 +1,20 @@
+---
+issue: 22
+---
+
+# Issue #22 — sea_surface marking + costmap dynamics: accumulate per-pixel softmax log-odds (drop the argmax gate), graded cost ramp, bounded recovery
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-29 10:11 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-22/plan.md` at `0513a92`
+**PR**: https://github.com/rolker/unh_marine_perception/pull/25 (`[PLAN]` prefix)
+**Phases**: 2 stacked PRs (P1 graded evidence + asymmetric clamp + reflex gate; P2 graded cost ramp + relay gradient)
+
+### Open questions
+- [ ] PR split: P1 (graded evidence + asymmetric clamp + reflex gate) then P2 (graded ramp + relay), or single PR? P1 alone fixes the #186 bug.
+- [ ] Reflex `τ` safety call — confidence before a faint obstacle triggers a Collision Monitor stop vs. only soft-biasing the route (surface to user).
+- [ ] Numeric defaults (`clear_floor`, thresholds, `τ`) provisional pending #186-bag R-distribution tuning.
+- [ ] Coordinate the `OccupancyObservation` struct change with the in-flight offline-core export (#23 / PR #24).

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -32,5 +32,24 @@ layer and relay; all params runtime-reconfigurable. Reflex/CA path untouched. Ne
 `cost_mapping.hpp`. Worked defaults: R=200→+0.85, R=120→+0.50, R=20→−0.85.
 
 ### Next
-- [ ] `/review-code` (pre-push) + Copilot review before merge.
+- [x] `/review-code` (pre-push) — done (see Local Review below).
 - [ ] On-water tune; activate planner cost weighting (separate config repo).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-29 11:25 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested → addressed
+**Branch**: feature/issue-22 at `9ac617b`
+**Mode**: pre-push
+**Depth**: Deep (reason: safety-relevant costmap C++, concurrency/lifecycle, shared cross-repo API)
+**Must-fix**: 2 (+1 promoted suggestion) | **Suggestions**: 2
+
+### Findings
+- [x] (must-fix) Layer + relay `updateCosts` overwrote master unconditionally — graded soft cost could downgrade another layer's INSCRIBED/LETHAL/unknown; switched to MAX-combine (updateWithMax semantics) — `sea_surface_layer.cpp:301`, `sea_surface_relay_layer.cpp:142` _(Copilot; Claude missed it)_
+- [x] (must-fix) `obstacle_prob_min`/`max_evidence_step` validated at runtime but not at `onInitialize` — bad YAML → ±inf/NaN logit, silent layer disable; added init clamp+WARN — `sea_surface_layer.cpp:112` _(Claude + Copilot, independent)_
+- [x] (promoted) `validate()` did not enforce `clear_floor <= free_threshold` → cleared water could publish positive cost; added guard — `occupancy_buffer.hpp:178` _(Copilot)_
+- [ ] (suggestion) `bag_to_costmap_video` A/B tool still renders binary (logOdds vs lethal), not the graded ramp — won't visualize the new gradient; follow-up _(Claude)_
+- [ ] (suggestion) cost ramp is coarse at the low end (occ=1→1, 2→4) — monotonic, below INSCRIBED; no action _(Claude)_
+
+Static analysis: cpplint flags are pre-existing house style (passes repo pre-commit). Cross-model adversarial agreed on the init-validation gap; Copilot uniquely caught the cost-downgrade regression.

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -195,9 +195,11 @@ if(BUILD_TESTING)
   # occupancy_buffer.hpp is the pure log-odds buffer (grid_map storage + rolling),
   # an exported core header (include/), exercised via this GTest. Links
   # grid_map_core for GridMap.
+  # cost_mapping.hpp (also exercised here) pulls nav2_costmap_2d cost constants.
   ament_add_gtest(test_occupancy_buffer test/test_occupancy_buffer.cpp)
   target_link_libraries(test_occupancy_buffer
     grid_map_core::grid_map_core
+    nav2_costmap_2d::nav2_costmap_2d_core
   )
 
   # occupancy_accumulator.hpp drives the per-frame move→decay→project→hit/miss

--- a/sea_surface_segmentation/config/README.md
+++ b/sea_surface_segmentation/config/README.md
@@ -90,9 +90,12 @@ IncludeLaunchDescription(
 
 A `nav2_costmap_2d::Layer` plugin that fuses one or more camera
 segmentation streams into a single persistent, decaying log-odds
-occupancy buffer in the costmap's global frame, and stamps cells whose
-accumulated evidence has crossed the lethal threshold into the master
-costmap. Replaces the pre-#19 per-camera layer instances (each with a
+occupancy buffer in the costmap's global frame, and stamps a graded cost
+into the master costmap: `LETHAL_OBSTACLE` at the lethal threshold and a
+soft cost ramp below it (per-cell occupancy `1..99` → cost `1..252`, kept
+below the inscribed cost so a graded cell never reads as an inscribed
+collision). Cells with no obstacle opinion are left untouched (the layer
+only ADDS). Replaces the pre-#19 per-camera layer instances (each with a
 private buffer wiped every frame), giving cross-camera fusion and
 short-term obstacle memory through FOV handoffs.
 
@@ -142,11 +145,13 @@ fewer flicker losses) and persists across FOV handoffs.
 | `maximum_range` | double | `100.0` | **yes** | Projection AABB half-extent per camera (m). |
 | `min_grazing_angle_deg` | double | `0.0` | **yes** | Reject rays that hit the water plane at less than this angle from horizontal. `0` = filter off. Bounds horizontal reach to ≈ `camera_height / tan(angle)`; cuts long-range noise where small pitch uncertainty produces large ground error. |
 | `published_topic` | string | `""` | no | When non-empty, republishes the lethal mask on this topic for `SeaSurfaceRelayLayer`. Empty = disabled. |
-| `hit_log_odds` | double | `0.85` | **yes** | Log-odds added on a waterline-contact observation. |
-| `miss_log_odds` | double | `-0.40` | **yes** | Log-odds added on a water (free-space) observation; negative. |
-| `clamp` | double | `5.0` | **yes** | Symmetric log-odds bound — keeps evidence revisable, prevents saturation. |
-| `lethal_threshold` | double | `1.0` | **yes** | Log-odds at or above which a cell stamps `LETHAL_OBSTACLE`. Must be in `(0, clamp]`. |
+| `obstacle_clamp` | double | `5.0` | **yes** | Upper log-odds bound — keeps obstacle evidence revisable, prevents saturation. |
+| `clear_floor` | double | `-2.0` | **yes** | Lower (negative) log-odds bound for accumulated water/free evidence. Must be `< 0`. |
+| `free_threshold` | double | `0.0` | **yes** | At or below this log-odds a cell has no obstacle opinion (occupancy `-1`; we only ADD cost). |
+| `lethal_threshold` | double | `1.0` | **yes** | Log-odds at or above which a cell reads as fully lethal (occupancy `100` → `LETHAL_OBSTACLE`). Require `free_threshold < lethal_threshold <= obstacle_clamp`. |
 | `decay_half_life_s` | double | `30.0` | **yes** | Unobserved evidence halves every this many wall-clock seconds. |
+| `obstacle_prob_min` | double | `0.35` | **yes** | Graded obstacle gate / decision prior. A pixel counts as obstacle-ish when `P(obstacle) >= obstacle_prob_min`, and the per-pixel logit's zero-crossing sits here (not 0.5) so marginal-but-positive evidence still contributes. Must be in `(0, 1)`. |
+| `max_evidence_step` | double | `0.85` | **yes** | Per-observation log-odds cap (flicker rejection); bounds any single frame's contribution. Must be `> 0`. |
 
 **Live-tunable**: change via `ros2 param set <costmap_node>
 <layer_name>.<param> <value>`. The validating
@@ -163,8 +168,11 @@ to apply" message so the operator isn't silently misled.
 - The layer projects pixel→world via the cell→pixel inverse direction
   (`project_observations_inverse` in `segments_projection.hpp`): iterate
   the world cells the camera can reach, classify each by the pixel it
-  covers. Waterline contact → hit (evidence ↑); water → miss
-  (evidence ↓); occluded body / sky pixels → skipped (no update). Only
+  covers. Each contributing pixel adds a **graded** log-odds increment:
+  a prior-shifted, `max_evidence_step`-capped logit of the red channel
+  (`255·P(obstacle)`), with the zero-crossing at `obstacle_prob_min`.
+  Waterline contact → positive evidence; water → negative; occluded
+  body / sky pixels → skipped (no update). Only
   the waterline contact gets back-projected onto the water plane (z=0);
   above-water body pixels would project past the real obstacle as a
   false "shadow" of lethal cells out to maximum_range.
@@ -179,13 +187,16 @@ to apply" message so the operator isn't silently misled.
 ## `sea_surface_layer::SeaSurfaceRelayLayer` (costmap_2d plugin)
 
 A thin counterpart to `SeaSurfaceLayer` for the case where the same
-lethal cells should reach a second costmap (typically the global
+graded costs should reach a second costmap (typically the global
 costmap, so `SmacPlannerHybrid` plans around buoys). The relay
 subscribes to a `nav_msgs::msg::OccupancyGrid` published by a peer
 `SeaSurfaceLayer` (running in another costmap, with `published_topic`
-set), and stamps `LETHAL_OBSTACLE` into its own master grid where the
-published cell is at or above `100`. The segmentation projection runs
-only once — in the producer.
+set), and stamps the **full graded gradient** into its own master grid:
+each published occupancy maps through the same `occupancy_to_cost`
+ramp as the producer (`1..99` → soft cost `1..252`, `100` →
+`LETHAL_OBSTACLE`); no-opinion cells (`-1`, or any occupancy `<= 0`)
+are left untouched. The segmentation projection runs only once — in
+the producer.
 
 ### Configuration
 
@@ -205,11 +216,12 @@ global_costmap:
 
 ### Behavior notes
 
-- Only cells published as `100` (lethal) stamp into the master; `-1`
-  ("no opinion") cells leave the master untouched, so the relay never
-  inadvertently clears another layer's marks (the global costmap's
-  chart + inflation contributions stay authoritative; sea-surface only
-  ADDS).
+- The full graded gradient is relayed: soft costs (`1..252`) plus
+  `LETHAL_OBSTACLE`, mapped from the published occupancy via
+  `occupancy_to_cost`. Cells with occupancy `<= 0` / `-1` ("no opinion")
+  leave the master untouched, so the relay never inadvertently clears
+  another layer's marks (the global costmap's chart + inflation
+  contributions stay authoritative; sea-surface only ADDS).
 - Cell-lookup is by world position, so the producer's costmap and the
   consumer's can have different pose / resolution / dimensions and the
   lethal cells still land at the correct world location.

--- a/sea_surface_segmentation/include/sea_surface_segmentation/cost_mapping.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/cost_mapping.hpp
@@ -1,0 +1,32 @@
+#ifndef SEA_SURFACE_SEGMENTATION__COST_MAPPING_HPP_
+#define SEA_SURFACE_SEGMENTATION__COST_MAPPING_HPP_
+
+#include <cmath>
+
+#include "nav2_costmap_2d/cost_values.hpp"
+
+namespace sea_surface_segmentation
+{
+
+// Map a published occupancy value [0..100] (or -1 = "no opinion") to a nav2
+// costmap cost, or -1 = "leave the master cell untouched". This is the only
+// place the graded occupancy ramp meets nav2's cost scale, so the costmap layer
+// and the relay layer share one mapping.
+//
+//   occ <= 0 / -1  → -1     (no opinion — never clears another layer's marks)
+//   occ == 100     → LETHAL_OBSTACLE (254)
+//   occ 1..99      → soft ramp 1..252 (stays strictly below INSCRIBED = 253, so
+//                                       a graded sea-surface cost never reads as
+//                                       an inscribed-radius collision)
+//
+// Pure logic — nav2_costmap_2d cost constants only (no rclcpp/grid_map).
+inline int occupancy_to_cost(int occ)
+{
+  if (occ <= 0) { return -1; }
+  if (occ >= 100) { return nav2_costmap_2d::LETHAL_OBSTACLE; }
+  return 1 + static_cast<int>(std::lround((occ - 1) / 98.0 * 251.0));
+}
+
+}  // namespace sea_surface_segmentation
+
+#endif  // SEA_SURFACE_SEGMENTATION__COST_MAPPING_HPP_

--- a/sea_surface_segmentation/include/sea_surface_segmentation/occupancy_accumulator.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/occupancy_accumulator.hpp
@@ -25,6 +25,8 @@ struct AccumulateParams
   double half_extent;                  // half-width (m) of the square iteration window
   double plane_z = 0.0;                // water-plane z in the world/target frame
   double min_grazing_angle_deg = 0.0;  // reject rays striking the plane shallower; 0 = no filter
+  double obstacle_prob_min = 0.35;     // graded obstacle gate / prior for pixel_log_odds
+  double max_evidence_step = 0.85;     // per-observation log-odds cap (flicker rejection)
 };
 
 // Per-frame driver: re-centre the rolling buffer on the boat, decay stale
@@ -46,7 +48,7 @@ struct AccumulateParams
 // the helper iterates a square axis-aligned window.
 //
 // Call order matters and is locked here: move() (roll the window to the boat) →
-// decay() (attenuate stale evidence by elapsed time) → project + hit/miss. The
+// decay() (attenuate stale evidence by elapsed time) → project + accumulate. The
 // `OccupancyBuffer` preserves overlapping evidence across a move() and seeds the
 // decay clock on the first decay() call.
 //
@@ -73,15 +75,12 @@ inline std::size_t accumulate_frame(
     project_observations_inverse(
       mask_rgb8, camera_model, camera_origin, rotation_cam_to_target,
       params.max_range, boat_x, boat_y, params.res, params.half_extent,
-      params.plane_z, params.min_grazing_angle_deg);
+      params.plane_z, params.min_grazing_angle_deg,
+      params.obstacle_prob_min, params.max_evidence_step);
 
   for (const auto & o : observations) {
     const grid_map::Position p(o.x, o.y);
-    if (o.obstacle) {
-      buffer.hit(p);
-    } else {
-      buffer.miss(p);
-    }
+    buffer.accumulate(p, o.log_odds);  // graded evidence (signed)
   }
   return observations.size();
 }

--- a/sea_surface_segmentation/include/sea_surface_segmentation/occupancy_buffer.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/occupancy_buffer.hpp
@@ -175,6 +175,13 @@ public:
     {
       why = "require free_threshold < lethal_threshold <= obstacle_clamp"; return false;
     }
+    // clear_floor must sit at or below free_threshold, so a maximally-cleared
+    // (floored) water cell reads as "no opinion" (occupancyAt → -1). If
+    // free_threshold were below clear_floor, even fully-cleared water would
+    // floor ABOVE free_threshold and publish a positive (soft-obstacle) cost.
+    if (!(p.clear_floor <= p.free_threshold)) {
+      why = "require clear_floor <= free_threshold"; return false;
+    }
     return true;
   }
 

--- a/sea_surface_segmentation/include/sea_surface_segmentation/occupancy_buffer.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/occupancy_buffer.hpp
@@ -15,10 +15,10 @@ namespace sea_surface_segmentation
 // reconfigurable on the live layer (validated via `validate()` before apply).
 struct OccupancyParams
 {
-  double hit_log_odds = 0.85;       // added to a cell on an obstacle observation
-  double miss_log_odds = -0.40;     // added on a free-space (water) observation; negative
-  double clamp = 5.0;               // |log-odds| bound, so evidence stays revisable (no saturation)
-  double lethal_threshold = 1.0;    // log-odds >= this => the cell reads as a lethal obstacle
+  double obstacle_clamp = 5.0;      // upper log-odds bound, so evidence stays revisable (no saturation)
+  double clear_floor = -2.0;        // lower (negative) log-odds bound for water/free evidence
+  double free_threshold = 0.0;      // log-odds <= this => no obstacle opinion (occupancy -1)
+  double lethal_threshold = 1.0;    // log-odds >= this => the cell reads as a lethal obstacle (occupancy 100)
   double decay_half_life_s = 30.0;  // unobserved evidence halves every this many seconds
 };
 
@@ -46,17 +46,32 @@ public:
     map_["log_odds"].setConstant(NAN);  // start fully unobserved
   }
 
+  // Wrap an existing GridMap (must carry a "log_odds" layer) + params. Used by
+  // the layer's publish path to run the read-only occupancy scan off-lock
+  // against a deep-copied snapshot while still going through `occupancyAt`.
+  // Decay state starts unseeded; this constructor is for read-only snapshots.
+  OccupancyBuffer(grid_map::GridMap map, const OccupancyParams & params)
+  : map_(std::move(map)), params_(params) {}
+
   // Roll the window so it re-centers on `position`. Overlapping cells keep their
   // accumulated evidence at the same world location; newly-exposed cells are NaN
   // (unobserved). Sub-cell motion is absorbed by grid_map's internal offset, so a
   // sequence of fractional-meter shifts does not drift evidence to a wrong cell.
   bool move(const grid_map::Position & position) { return map_.move(position); }
 
-  // Accumulate an obstacle observation at `position` (clamped log-odds).
-  bool hit(const grid_map::Position & position) { return apply(position, params_.hit_log_odds); }
-
-  // Accumulate a free-space (water) observation at `position` (clamped log-odds).
-  bool miss(const grid_map::Position & position) { return apply(position, params_.miss_log_odds); }
+  // Accumulate a graded log-odds `increment` (signed) at `position`. The result
+  // is clamped to [clear_floor, obstacle_clamp]. NaN (unobserved) reads as the
+  // prior (0) before adding. Returns false (no-op) if the position is outside
+  // the window.
+  bool accumulate(const grid_map::Position & position, double increment)
+  {
+    if (!map_.isInside(position)) { return false; }
+    float & v = map_.atPosition("log_odds", position);
+    const double current = std::isfinite(v) ? static_cast<double>(v) : 0.0;  // NaN => prior
+    v = static_cast<float>(
+      std::clamp(current + increment, params_.clear_floor, params_.obstacle_clamp));
+    return true;
+  }
 
   // Decay all observed cells toward the prior based on wall-clock elapsed time.
   // Call once per update cycle with the current time; the first call only seeds
@@ -83,6 +98,29 @@ public:
     if (!map_.isInside(position)) { return false; }
     const float v = map_.atPosition("log_odds", position);
     return std::isfinite(v) && static_cast<double>(v) >= params_.lethal_threshold;
+  }
+
+  // Graded occupancy at `position`, in the published-OccupancyGrid convention:
+  //   - unobserved (NaN) or outside the window → -1 ("no opinion")
+  //   - log-odds <= free_threshold            → -1 (we only ADD cost; clearing
+  //                                                 unknown/free is left to other
+  //                                                 layers)
+  //   - log-odds >= lethal_threshold          → 100 (lethal)
+  //   - otherwise a linear ramp 1..99 across (free_threshold, lethal_threshold)
+  // Pure logic — no nav2 cost mapping here (see cost_mapping.hpp).
+  int occupancyAt(const grid_map::Position & position) const
+  {
+    if (!map_.isInside(position)) { return -1; }
+    const float vf = map_.atPosition("log_odds", position);
+    if (!std::isfinite(vf)) { return -1; }
+    const double v = static_cast<double>(vf);
+    if (v <= params_.free_threshold) { return -1; }
+    if (v >= params_.lethal_threshold) { return 100; }
+    const double frac =
+      (v - params_.free_threshold) /
+      (params_.lethal_threshold - params_.free_threshold);
+    const long occ = 1 + std::lround(frac * 98.0);
+    return static_cast<int>(std::clamp<long>(occ, 1, 99));
   }
 
   // Raw log-odds at `position`; NaN if unobserved or outside the window.
@@ -114,39 +152,33 @@ public:
   // returns false and sets `why`.
   static bool validate(const OccupancyParams & p, std::string & why)
   {
-    if (!std::isfinite(p.hit_log_odds) || p.hit_log_odds <= 0.0) {
-      why = "hit_log_odds must be finite and > 0"; return false;
+    if (!std::isfinite(p.obstacle_clamp) || p.obstacle_clamp <= 0.0) {
+      why = "obstacle_clamp must be finite and > 0"; return false;
     }
-    if (!std::isfinite(p.miss_log_odds) || p.miss_log_odds >= 0.0) {
-      why = "miss_log_odds must be finite and < 0"; return false;
-    }
-    if (!std::isfinite(p.clamp) || p.clamp <= 0.0) {
-      why = "clamp must be finite and > 0"; return false;
-    }
-    if (!std::isfinite(p.lethal_threshold) || p.lethal_threshold <= 0.0 ||
-      p.lethal_threshold > p.clamp)
-    {
-      // Lower bound matters: a threshold of 0 makes a single hit lethal (defeats
-      // flicker rejection); a negative one makes a water `miss` read lethal — a
-      // safety inversion on an obstacle layer.
-      why = "lethal_threshold must be finite and in (0, clamp]"; return false;
+    if (!std::isfinite(p.clear_floor) || p.clear_floor >= 0.0) {
+      why = "clear_floor must be finite and < 0"; return false;
     }
     if (!std::isfinite(p.decay_half_life_s) || p.decay_half_life_s <= 0.0) {
       why = "decay_half_life_s must be finite and > 0"; return false;
+    }
+    if (!std::isfinite(p.free_threshold)) {
+      why = "free_threshold must be finite"; return false;
+    }
+    if (!std::isfinite(p.lethal_threshold)) {
+      why = "lethal_threshold must be finite"; return false;
+    }
+    // free_threshold < lethal_threshold <= obstacle_clamp. A non-positive
+    // ordering here would invert the ramp / make a single observation lethal /
+    // place the lethal level above the clamp (unreachable).
+    if (!(p.free_threshold < p.lethal_threshold) ||
+      !(p.lethal_threshold <= p.obstacle_clamp))
+    {
+      why = "require free_threshold < lethal_threshold <= obstacle_clamp"; return false;
     }
     return true;
   }
 
 private:
-  bool apply(const grid_map::Position & position, double increment)
-  {
-    if (!map_.isInside(position)) { return false; }
-    float & v = map_.atPosition("log_odds", position);
-    const double current = std::isfinite(v) ? static_cast<double>(v) : 0.0;  // NaN => prior
-    v = static_cast<float>(std::clamp(current + increment, -params_.clamp, params_.clamp));
-    return true;
-  }
-
   grid_map::GridMap map_;
   OccupancyParams params_;
   double last_decay_s_ = 0.0;

--- a/sea_surface_segmentation/include/sea_surface_segmentation/occupancy_buffer.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/occupancy_buffer.hpp
@@ -62,10 +62,12 @@ public:
   // Accumulate a graded log-odds `increment` (signed) at `position`. The result
   // is clamped to [clear_floor, obstacle_clamp]. NaN (unobserved) reads as the
   // prior (0) before adding. Returns false (no-op) if the position is outside
-  // the window.
+  // the window OR the increment is non-finite — a NaN/Inf increment must never
+  // be stored: std::clamp would propagate the NaN, turning an observed cell back
+  // into "unobserved" and silently dropping accumulated evidence.
   bool accumulate(const grid_map::Position & position, double increment)
   {
-    if (!map_.isInside(position)) { return false; }
+    if (!map_.isInside(position) || !std::isfinite(increment)) { return false; }
     float & v = map_.atPosition("log_odds", position);
     const double current = std::isfinite(v) ? static_cast<double>(v) : 0.0;  // NaN => prior
     v = static_cast<float>(

--- a/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
@@ -8,6 +8,7 @@
 // so they all compute the costmap with the real code. See
 // rolker/unh_marine_perception#23.
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -18,6 +19,26 @@
 #include "image_geometry/pinhole_camera_model.hpp"
 
 namespace sea_surface_segmentation {
+
+// Per-observation log-odds increment for a pixel with red value `R` (0..255 =
+// 255·P(obstacle) from the per-pixel softmax). A prior-shifted, capped logit:
+//
+//   logit_R     = ln((R + eps) / (255 - R + eps))   — observed evidence in log-odds
+//   logit_prior = ln(prob_min / (1 - prob_min))     — the decision prior
+//   d           = logit_R - logit_prior             — zero-crossing at P(obs)==prob_min
+//
+// Shifting by the prior puts the zero-crossing at `obstacle_prob_min` rather than
+// 0.5, so a buoy where water is marginally more likely (e.g. P_obs=0.47 with
+// prob_min=0.35) still contributes POSITIVE evidence. `max_step` caps any single
+// frame for flicker rejection (and preserves ~2-frame-to-lethal at defaults).
+inline double pixel_log_odds(int R, double obstacle_prob_min, double max_step)
+{
+  const double eps = 0.5;
+  const double logit_R     = std::log((R + eps) / (255.0 - R + eps));
+  const double logit_prior = std::log(obstacle_prob_min / (1.0 - obstacle_prob_min));
+  double d = logit_R - logit_prior;          // zero-crossing at P(obs)==obstacle_prob_min
+  return std::clamp(d, -max_step, max_step);
+}
 
 // One projected obstacle point in the target frame (3D) with the
 // red-channel intensity copied through from the mask pixel.
@@ -249,6 +270,7 @@ struct OccupancyObservation
   double x;
   double y;
   bool obstacle;
+  double log_odds = 0.0;  // graded per-observation evidence increment (signed)
 };
 
 // Back-project a segmentation mask into ground-plane occupancy observations for
@@ -324,7 +346,11 @@ inline std::vector<OccupancyObservation> project_observations(
       if (std::sqrt(dx * dx + dy * dy + dz * dz) > max_range) {
         continue;  // beyond sensor range
       }
-      observations.push_back({wx, wy, obstacle_obs});
+      // Forward path is not the live costmap path; populate log_odds for
+      // self-consistency only, using a neutral 0.5 prior so a red-dominant
+      // pixel yields positive and water yields negative evidence.
+      observations.push_back(
+        {wx, wy, obstacle_obs, pixel_log_odds(pixel_value[0], 0.5, 0.85)});
     }
   }
 
@@ -359,13 +385,31 @@ inline std::vector<OccupancyObservation> project_observations_inverse(
   double max_range,
   double cx, double cy, double res, double half_extent,
   double plane_z = 0.0,
-  double min_grazing_angle_deg = 0.0)
+  double min_grazing_angle_deg = 0.0,
+  double obstacle_prob_min = 0.5,
+  double max_evidence_step = 0.85)
 {
-  // Lowest (nearest) waterline contact per column — same primitive as forward.
+  // Graded obstacle gate: a pixel counts as obstacle-ish when its red channel
+  // (255·P(obstacle)) implies P(obstacle) >= obstacle_prob_min. Replaces the
+  // argmax `is_obstacle_pixel`/`is_waterline_contact_pixel` gate on the costmap
+  // path so marginal-but-positive evidence (e.g. a buoy where water is barely
+  // more likely) is not silently dropped before the graded log-odds step.
+  auto is_obstacle_ish = [&](const cv::Vec3b & px) {
+    return px[0] >= obstacle_prob_min * 255.0;
+  };
+
+  // Lowest (largest-row) obstacle-ish pixel per column whose pixel directly
+  // below is NOT obstacle-ish (or which sits on the bottom row). Same waterline
+  // contact geometry as forward, but using the graded gate.
   std::vector<int> contact_row(mask_rgb8.cols, -1);
   for (int col = 0; col < mask_rgb8.cols; ++col) {
     for (int row = mask_rgb8.rows - 1; row >= 0; --row) {
-      if (is_waterline_contact_pixel(mask_rgb8, row, col)) {
+      if (!is_obstacle_ish(mask_rgb8.at<cv::Vec3b>(row, col))) {
+        continue;
+      }
+      if (row + 1 >= mask_rgb8.rows ||
+        !is_obstacle_ish(mask_rgb8.at<cv::Vec3b>(row + 1, col)))
+      {
         contact_row[col] = row;
         break;
       }
@@ -402,13 +446,17 @@ inline std::vector<OccupancyObservation> project_observations_inverse(
       const int v = static_cast<int>(std::lround(uv.y));
       if (u < 0 || u >= mask_rgb8.cols || v < 0 || v >= mask_rgb8.rows) { continue; }
       const cv::Vec3b px = mask_rgb8.at<cv::Vec3b>(v, u);
-      if (is_obstacle_pixel(px)) {
+      if (is_obstacle_ish(px)) {
         if (v == contact_row[u]) {
-          observations.push_back({wx, wy, true});         // waterline contact → hit
+          observations.push_back(
+            {wx, wy, true,
+             pixel_log_odds(px[0], obstacle_prob_min, max_evidence_step)});  // waterline contact → +evidence
         }
         // else: above (or below an unselected) contact = body → leave unobserved
       } else if (px[1] > px[0] && px[1] > px[2]) {        // green-dominant = water
-        observations.push_back({wx, wy, false});          // positively observed water → miss
+        observations.push_back(
+          {wx, wy, false,
+           pixel_log_odds(px[0], obstacle_prob_min, max_evidence_step)});  // observed water → -evidence
       }
       // else: sky (blue-dominant) or ambiguous → skip (no observation)
     }

--- a/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
@@ -31,8 +31,20 @@ namespace sea_surface_segmentation {
 // 0.5, so a buoy where water is marginally more likely (e.g. P_obs=0.47 with
 // prob_min=0.35) still contributes POSITIVE evidence. `max_step` caps any single
 // frame for flicker rejection (and preserves ~2-frame-to-lethal at defaults).
+//
+// Defensive: this is an exported utility also called by offline tools/tuners
+// (rolker/unh_marine_perception#23) that don't run the layer's parameter
+// validation. Out-of-range inputs return 0.0 (contribute no evidence) rather
+// than feeding NaN/Inf — or tripping std::clamp's lo<=hi precondition — into the
+// occupancy buffer. The live layer still validates these at init + on set.
 inline double pixel_log_odds(int R, double obstacle_prob_min, double max_step)
 {
+  if (R < 0) { R = 0; } else if (R > 255) { R = 255; }
+  if (!(obstacle_prob_min > 0.0 && obstacle_prob_min < 1.0) ||
+    !std::isfinite(max_step) || max_step <= 0.0)
+  {
+    return 0.0;  // invalid params — no opinion rather than NaN/Inf/UB
+  }
   const double eps = 0.5;
   const double logit_R     = std::log((R + eps) / (255.0 - R + eps));
   const double logit_prior = std::log(obstacle_prob_min / (1.0 - obstacle_prob_min));

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -109,6 +109,29 @@ public:
     declareParameter("max_evidence_step", rclcpp::ParameterValue(max_evidence_step_));
     node->get_parameter(name_ + ".max_evidence_step", max_evidence_step_);
 
+    // Validate the projection knobs at startup (they live on the layer, not in
+    // OccupancyParams, so OccupancyBuffer::validate below doesn't cover them).
+    // Mirror the runtime onParametersSet checks + the min_grazing_angle_deg
+    // clamp-to-default pattern: a bad YAML value must not flow into the logit
+    // math. obstacle_prob_min must be in (0,1) — 0 or 1 makes logit(prior) ±inf
+    // (saturates / disables grading) and NaN silently disables the whole layer;
+    // max_evidence_step must be finite and > 0 (a negative gives std::clamp
+    // lo > hi, which is UB).
+    if (!std::isfinite(obstacle_prob_min_) ||
+      obstacle_prob_min_ <= 0.0 || obstacle_prob_min_ >= 1.0)
+    {
+      RCLCPP_WARN_STREAM(
+        logger_, "Invalid obstacle_prob_min (" << obstacle_prob_min_
+          << "); must be in (0, 1). Using default 0.35.");
+      obstacle_prob_min_ = 0.35;
+    }
+    if (!std::isfinite(max_evidence_step_) || max_evidence_step_ <= 0.0) {
+      RCLCPP_WARN_STREAM(
+        logger_, "Invalid max_evidence_step (" << max_evidence_step_
+          << "); must be finite and > 0. Using default 0.85.");
+      max_evidence_step_ = 0.85;
+    }
+
     std::string why;
     if (!sea_surface_segmentation::OccupancyBuffer::validate(params_, why)) {
       RCLCPP_WARN_STREAM(
@@ -300,10 +323,20 @@ public:
         master_grid.mapToWorld(static_cast<unsigned int>(i), static_cast<unsigned int>(j), wx, wy);
         const int occ = buffer_->occupancyAt(grid_map::Position(wx, wy));
         const int c = sea_surface_segmentation::occupancy_to_cost(occ);
-        if (c >= 0) {
-          master_grid.setCost(
-            static_cast<unsigned int>(i), static_cast<unsigned int>(j),
-            static_cast<unsigned char>(c));
+        if (c < 0) {
+          continue;  // no obstacle opinion — leave the master cell untouched
+        }
+        // Combine with MAX (nav2 updateWithMax semantics): only raise a known
+        // cost, and write over unknown. A graded soft cost (1..252) must never
+        // downgrade another layer's INSCRIBED / LETHAL mark — sea-surface only
+        // ADDS risk.
+        const unsigned int mi = static_cast<unsigned int>(i);
+        const unsigned int mj = static_cast<unsigned int>(j);
+        const unsigned char old_cost = master_grid.getCost(mi, mj);
+        if (old_cost == nav2_costmap_2d::NO_INFORMATION ||
+          old_cost < static_cast<unsigned char>(c))
+        {
+          master_grid.setCost(mi, mj, static_cast<unsigned char>(c));
         }
       }
     }

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -19,6 +19,7 @@
 #include "nav2_costmap_2d/layer.hpp"
 #include "nav2_costmap_2d/layered_costmap.hpp"
 
+#include "sea_surface_segmentation/cost_mapping.hpp"
 #include "sea_surface_segmentation/occupancy_buffer.hpp"
 #include "sea_surface_segmentation/segments_projection.hpp"
 
@@ -88,17 +89,25 @@ public:
       min_grazing_angle_deg_ = 0.0;
     }
 
-    // Log-odds occupancy parameters (runtime-tunable wiring is phase 6).
-    declareParameter("hit_log_odds", rclcpp::ParameterValue(params_.hit_log_odds));
-    node->get_parameter(name_ + ".hit_log_odds", params_.hit_log_odds);
-    declareParameter("miss_log_odds", rclcpp::ParameterValue(params_.miss_log_odds));
-    node->get_parameter(name_ + ".miss_log_odds", params_.miss_log_odds);
-    declareParameter("clamp", rclcpp::ParameterValue(params_.clamp));
-    node->get_parameter(name_ + ".clamp", params_.clamp);
+    // Graded log-odds occupancy parameters (all runtime-tunable).
+    declareParameter("obstacle_clamp", rclcpp::ParameterValue(params_.obstacle_clamp));
+    node->get_parameter(name_ + ".obstacle_clamp", params_.obstacle_clamp);
+    declareParameter("clear_floor", rclcpp::ParameterValue(params_.clear_floor));
+    node->get_parameter(name_ + ".clear_floor", params_.clear_floor);
+    declareParameter("free_threshold", rclcpp::ParameterValue(params_.free_threshold));
+    node->get_parameter(name_ + ".free_threshold", params_.free_threshold);
     declareParameter("lethal_threshold", rclcpp::ParameterValue(params_.lethal_threshold));
     node->get_parameter(name_ + ".lethal_threshold", params_.lethal_threshold);
     declareParameter("decay_half_life_s", rclcpp::ParameterValue(params_.decay_half_life_s));
     node->get_parameter(name_ + ".decay_half_life_s", params_.decay_half_life_s);
+
+    // Graded evidence-model knobs (live-tunable). `obstacle_prob_min` shifts the
+    // zero-crossing of the per-pixel logit; `max_evidence_step` caps any single
+    // frame's contribution. Read fresh each segmentsCallback under the lock.
+    declareParameter("obstacle_prob_min", rclcpp::ParameterValue(obstacle_prob_min_));
+    node->get_parameter(name_ + ".obstacle_prob_min", obstacle_prob_min_);
+    declareParameter("max_evidence_step", rclcpp::ParameterValue(max_evidence_step_));
+    node->get_parameter(name_ + ".max_evidence_step", max_evidence_step_);
 
     std::string why;
     if (!sea_surface_segmentation::OccupancyBuffer::validate(params_, why)) {
@@ -191,8 +200,9 @@ public:
     }
 
     // Live-tunable params via `ros2 param set` (phase 6). Decay half-life,
-    // hit/miss increments, clamp, lethal threshold, and maximum_range all
-    // reconfigure at runtime; topic and source-list params stay configure-time
+    // obstacle_clamp, clear_floor, free/lethal thresholds, obstacle_prob_min,
+    // max_evidence_step, and maximum_range all reconfigure at runtime; topic
+    // and source-list params stay configure-time
     // (subscriber re-bind is not supported here). The callback validates the
     // proposed change before applying — a fat-fingered set can't silently
     // poison the buffer interpretation.
@@ -280,16 +290,20 @@ public:
     if (!buffer_) {
       return;
     }
-    // Stamp LETHAL into the master where the buffer has crossed the threshold.
-    // Leave everything else untouched (other layers + inflation own free/unknown).
+    // Stamp the graded cost into the master from the buffer's occupancy ramp:
+    // LETHAL at the lethal threshold, a soft cost below it, and nothing where the
+    // buffer has no obstacle opinion (occ <= 0 → cost -1). We only ADD; free /
+    // unknown remain owned by other layers + inflation.
     for (int i = min_i; i < max_i; ++i) {
       for (int j = min_j; j < max_j; ++j) {
         double wx, wy;
         master_grid.mapToWorld(static_cast<unsigned int>(i), static_cast<unsigned int>(j), wx, wy);
-        if (buffer_->isLethal(grid_map::Position(wx, wy))) {
+        const int occ = buffer_->occupancyAt(grid_map::Position(wx, wy));
+        const int c = sea_surface_segmentation::occupancy_to_cost(occ);
+        if (c >= 0) {
           master_grid.setCost(
             static_cast<unsigned int>(i), static_cast<unsigned int>(j),
-            nav2_costmap_2d::LETHAL_OBSTACLE);
+            static_cast<unsigned char>(c));
         }
       }
     }
@@ -358,12 +372,16 @@ private:
     double res;
     double maximum_range;
     double min_grazing_deg;
+    double obstacle_prob_min;
+    double max_evidence_step;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       camera_model = src.camera_model;
       res = resolution_;
       maximum_range = maximum_range_;
       min_grazing_deg = min_grazing_angle_deg_;
+      obstacle_prob_min = obstacle_prob_min_;
+      max_evidence_step = max_evidence_step_;
     }
     if (!camera_model || res <= 0.0) {
       return;
@@ -399,7 +417,7 @@ private:
       const auto observations = sea_surface_segmentation::project_observations_inverse(
         image->image, *camera_model, camera_origin, rotation_cam_to_world,
         maximum_range, camera_origin[0], camera_origin[1], res, maximum_range,
-        /*plane_z=*/0.0, min_grazing_deg);
+        /*plane_z=*/0.0, min_grazing_deg, obstacle_prob_min, max_evidence_step);
 
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       if (!buffer_) {
@@ -407,11 +425,7 @@ private:
       }
       for (const auto & obs : observations) {
         const grid_map::Position p(obs.x, obs.y);
-        if (obs.obstacle) {
-          buffer_->hit(p);
-        } else {
-          buffer_->miss(p);
-        }
+        buffer_->accumulate(p, obs.log_odds);  // graded evidence (signed)
       }
       // Mark the layer current so LayeredCostmap::isCurrent() doesn't report a
       // stale layer once a frame has been ingested. Stays true once set — the
@@ -450,13 +464,13 @@ private:
     src.camera_model = model;
   }
 
-  // Publish the lethal-cell mask as a nav_msgs/OccupancyGrid so a downstream
-  // `SeaSurfaceRelayLayer` (or any consumer) can stamp the same lethal cells
+  // Publish the graded occupancy as a nav_msgs/OccupancyGrid so a downstream
+  // `SeaSurfaceRelayLayer` (or any consumer) can stamp the same graded gradient
   // into a different costmap without rerunning the segmentation projection.
-  // Cells at or above the lethal threshold publish as 100; everything else
-  // (unobserved or sub-threshold) publishes as -1 ("no opinion") so the
-  // consumer never inadvertently clears another layer's marks. Header frame
-  // is the costmap's global frame (e.g. `map_tide`).
+  // Each cell carries its `occupancyAt` value: 100 at the lethal threshold, a
+  // soft 1..99 ramp below it, and -1 ("no opinion") where the buffer has no
+  // obstacle evidence, so the consumer never inadvertently clears another
+  // layer's marks. Header frame is the costmap's global frame (e.g. `map_tide`).
   void publishLethalGrid()
   {
     if (!lethal_publisher_) {
@@ -474,15 +488,21 @@ private:
     // — 160 kB on the same 200×200) — far cheaper than holding the lock
     // through the scan.
     grid_map::GridMap map_copy;
-    double threshold;
+    sea_surface_segmentation::OccupancyParams occ_params;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       if (!buffer_) {
         return;
       }
       map_copy = buffer_->map();  // grid_map copy assignment = deep copy of Eigen data
-      threshold = params_.lethal_threshold;
+      occ_params = params_;
     }
+    // Standalone copy of the buffer so the O(W*H) occupancy scan runs off-lock
+    // against the snapshot, yet still goes through `occupancyAt` (single source
+    // of the graded ramp). The OccupancyBuffer is move-cheap (it holds the
+    // GridMap we already deep-copied); rebuilding around `map_copy` avoids a
+    // duplicate ramp implementation here.
+    sea_surface_segmentation::OccupancyBuffer snapshot(map_copy, occ_params);
 
     nav_msgs::msg::OccupancyGrid msg;
     msg.header.stamp = node->now();
@@ -510,13 +530,8 @@ private:
         const double wx = msg.info.origin.position.x + (x + 0.5) * msg.info.resolution;
         const double wy = msg.info.origin.position.y + (y + 0.5) * msg.info.resolution;
         const grid_map::Position p(wx, wy);
-        if (!map_copy.isInside(p)) {
-          continue;
-        }
-        const float v = map_copy.atPosition("log_odds", p);
-        if (std::isfinite(v) && static_cast<double>(v) >= threshold) {
-          msg.data[static_cast<size_t>(y) * msg.info.width + x] = 100;
-        }
+        msg.data[static_cast<size_t>(y) * msg.info.width + x] =
+          static_cast<int8_t>(snapshot.occupancyAt(p));
       }
     }
 
@@ -542,11 +557,15 @@ private:
     sea_surface_segmentation::OccupancyParams candidate_occ;
     double candidate_max_range;
     double candidate_min_grazing_deg;
+    double candidate_obstacle_prob_min;
+    double candidate_max_evidence_step;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       candidate_occ = params_;
       candidate_max_range = maximum_range_;
       candidate_min_grazing_deg = min_grazing_angle_deg_;
+      candidate_obstacle_prob_min = obstacle_prob_min_;
+      candidate_max_evidence_step = max_evidence_step_;
     }
 
     // Configure-time params — subscriber re-bind / publisher re-bind isn't
@@ -590,16 +609,32 @@ private:
           return result;
         }
 
-        if (n == name_ + ".hit_log_odds") {
-          candidate_occ.hit_log_odds = p.as_double();
-        } else if (n == name_ + ".miss_log_odds") {
-          candidate_occ.miss_log_odds = p.as_double();
-        } else if (n == name_ + ".clamp") {
-          candidate_occ.clamp = p.as_double();
+        if (n == name_ + ".obstacle_clamp") {
+          candidate_occ.obstacle_clamp = p.as_double();
+        } else if (n == name_ + ".clear_floor") {
+          candidate_occ.clear_floor = p.as_double();
+        } else if (n == name_ + ".free_threshold") {
+          candidate_occ.free_threshold = p.as_double();
         } else if (n == name_ + ".lethal_threshold") {
           candidate_occ.lethal_threshold = p.as_double();
         } else if (n == name_ + ".decay_half_life_s") {
           candidate_occ.decay_half_life_s = p.as_double();
+        } else if (n == name_ + ".obstacle_prob_min") {
+          const double v = p.as_double();
+          if (!std::isfinite(v) || v <= 0.0 || v >= 1.0) {
+            result.successful = false;
+            result.reason = "obstacle_prob_min must be finite and in (0, 1)";
+            return result;
+          }
+          candidate_obstacle_prob_min = v;
+        } else if (n == name_ + ".max_evidence_step") {
+          const double v = p.as_double();
+          if (!std::isfinite(v) || v <= 0.0) {
+            result.successful = false;
+            result.reason = "max_evidence_step must be finite and > 0";
+            return result;
+          }
+          candidate_max_evidence_step = v;
         } else if (n == name_ + ".maximum_range") {
           const double v = p.as_double();
           if (!std::isfinite(v) || v <= 0.0) {
@@ -635,6 +670,8 @@ private:
     params_ = candidate_occ;
     maximum_range_ = candidate_max_range;
     min_grazing_angle_deg_ = candidate_min_grazing_deg;
+    obstacle_prob_min_ = candidate_obstacle_prob_min;
+    max_evidence_step_ = candidate_max_evidence_step;
     if (buffer_) {
       buffer_->setParams(params_);
     }
@@ -653,6 +690,9 @@ private:
 
   double maximum_range_ = 100.0;
   double min_grazing_angle_deg_ = 0.0;  // 0 = filter off (back-compat)
+  // Graded evidence-model knobs (live-tunable; snapshotted per segmentsCallback).
+  double obstacle_prob_min_ = 0.35;
+  double max_evidence_step_ = 0.85;
   sea_surface_segmentation::OccupancyParams params_;
   std::unique_ptr<sea_surface_segmentation::OccupancyBuffer> buffer_;
 

--- a/sea_surface_segmentation/src/sea_surface_relay_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_relay_layer.cpp
@@ -141,10 +141,19 @@ public:
         }
         const int occ = msg->data[static_cast<size_t>(y) * mw + x];
         const int c = sea_surface_segmentation::occupancy_to_cost(occ);
-        if (c >= 0) {
-          master_grid.setCost(
-            static_cast<unsigned int>(i), static_cast<unsigned int>(j),
-            static_cast<unsigned char>(c));
+        if (c < 0) {
+          continue;  // no opinion — leave the master cell untouched
+        }
+        // Combine with MAX (nav2 updateWithMax semantics): only raise a known
+        // cost, write over unknown. A relayed soft cost must never downgrade a
+        // stronger upstream mark — the relay only ADDS, like the producer.
+        const unsigned int mi = static_cast<unsigned int>(i);
+        const unsigned int mj = static_cast<unsigned int>(j);
+        const unsigned char old_cost = master_grid.getCost(mi, mj);
+        if (old_cost == nav2_costmap_2d::NO_INFORMATION ||
+          old_cost < static_cast<unsigned char>(c))
+        {
+          master_grid.setCost(mi, mj, static_cast<unsigned char>(c));
         }
       }
     }

--- a/sea_surface_segmentation/src/sea_surface_relay_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_relay_layer.cpp
@@ -12,23 +12,26 @@
 #include "nav2_costmap_2d/layer.hpp"
 #include "nav2_costmap_2d/layered_costmap.hpp"
 
+#include "sea_surface_segmentation/cost_mapping.hpp"
+
 namespace sea_surface_layer
 {
 
-// Thin costmap layer that stamps LETHAL where a peer SeaSurfaceLayer (running
-// in a different costmap, typically local) has published its lethal cells.
+// Thin costmap layer that relays a peer SeaSurfaceLayer's published graded
+// occupancy (running in a different costmap, typically local) into this costmap.
 //
 // Why a relay instead of a second SeaSurfaceLayer in the global costmap: the
 // segmentation projection is the expensive step (N cameras × image-size
 // iterations per frame); running it twice (once per costmap) would double the
-// cost for no information gain since both costmaps end up with the same lethal
-// cells. The producer publishes once; this consumer copies. Mirrors the
-// s57_grids / s57_layer producer/consumer pattern.
+// cost for no information gain since both costmaps end up with the same cells.
+// The producer publishes once; this consumer copies. Mirrors the s57_grids /
+// s57_layer producer/consumer pattern.
 //
-// Only the LETHAL cells are stamped. Sub-threshold and unobserved cells (-1 in
-// the published OccupancyGrid) are left untouched so the relay never clears
-// another layer's marks — the global costmap's chart/inflation contributions
-// stay authoritative; sea-surface only ADDS.
+// The full graded gradient is relayed: each published cell maps through
+// `occupancy_to_cost` to a soft cost (1..252) or LETHAL (254). Unobserved /
+// no-opinion cells (-1, or any occupancy <= 0) map to "leave untouched", so the
+// relay never clears another layer's marks — the global costmap's
+// chart/inflation contributions stay authoritative; sea-surface only ADDS.
 class SeaSurfaceRelayLayer: public nav2_costmap_2d::Layer
 {
 public:
@@ -136,10 +139,12 @@ public:
         if (x >= mw || y >= mh) {
           continue;
         }
-        if (msg->data[static_cast<size_t>(y) * mw + x] >= 100) {
+        const int occ = msg->data[static_cast<size_t>(y) * mw + x];
+        const int c = sea_surface_segmentation::occupancy_to_cost(occ);
+        if (c >= 0) {
           master_grid.setCost(
             static_cast<unsigned int>(i), static_cast<unsigned int>(j),
-            nav2_costmap_2d::LETHAL_OBSTACLE);
+            static_cast<unsigned char>(c));
         }
       }
     }

--- a/sea_surface_segmentation/test/test_occupancy_accumulator.cpp
+++ b/sea_surface_segmentation/test/test_occupancy_accumulator.cpp
@@ -16,6 +16,7 @@ using sea_surface_segmentation::accumulate_frame;
 using sea_surface_segmentation::AccumulateParams;
 using sea_surface_segmentation::OccupancyBuffer;
 using sea_surface_segmentation::OccupancyParams;
+using sea_surface_segmentation::pixel_log_odds;
 using sea_surface_segmentation::project_observations_inverse;
 
 namespace
@@ -91,6 +92,12 @@ AccumulateParams acc_params()
   return AccumulateParams{/*max_range=*/100.0, kRes, kHalfExtent};
 }
 
+// The graded log-odds increment a single R=200 waterline-contact pixel
+// contributes under the AccumulateParams defaults (obstacle_prob_min=0.35,
+// max_evidence_step=0.85). All accumulator tests below assert against this rather
+// than the removed flat `hit_log_odds`.
+const double kContact = pixel_log_odds(200, 0.35, 0.85);
+
 }  // namespace
 
 // A single all-water frame applies a miss to every observed water cell and
@@ -114,8 +121,11 @@ TEST(AccumulateFrame, AllWaterAppliesMissesAndReturnsObservationCount)
 
   EXPECT_GT(applied, 0u) << "in-footprint water cells should be observed";
   EXPECT_EQ(applied, direct.size()) << "driver must apply exactly the projected observations";
-  // The centre pixel (8,6) covers world (0,0); under all-water it is a miss.
-  EXPECT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), params.miss_log_odds, kLogOddsTol);
+  // The centre pixel (8,6) covers world (0,0); under all-water (R=0) it is a
+  // negative (water) graded increment.
+  const double kWater = pixel_log_odds(0, p.obstacle_prob_min, p.max_evidence_step);
+  EXPECT_LT(kWater, 0.0) << "water pixel must yield negative evidence";
+  EXPECT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), kWater, kLogOddsTol);
 }
 
 // A single obstacle contact pixel at image centre marks the world-(0,0) cell as
@@ -132,9 +142,10 @@ TEST(AccumulateFrame, ContactPixelMarksHitCell)
     buffer, mask, model, kNadirOrigin, nadir_rotation(),
     0.0, 0.0, 100.0, acc_params());
 
-  // (0,0) ← pixel (8,6) = the contact → one hit.
-  EXPECT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), params.hit_log_odds, kLogOddsTol);
-  // A neighbour cell (0.25,0) ← a water pixel → miss (negative).
+  // (0,0) ← pixel (8,6) = the contact → one graded hit (R=200).
+  EXPECT_GT(kContact, 0.0) << "a contact pixel must yield positive evidence";
+  EXPECT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), kContact, kLogOddsTol);
+  // A neighbour cell (0.25,0) ← a water pixel → negative evidence.
   EXPECT_LT(buffer.logOdds(grid_map::Position(0.25, 0.0)), 0.0);
 }
 
@@ -152,7 +163,7 @@ TEST(AccumulateFrame, MovePreservesOverlappingEvidence)
   contact.at<cv::Vec3b>(6, 8) = cv::Vec3b(200, 0, 0);
   accumulate_frame(buffer, contact, model, kNadirOrigin, nadir_rotation(),
     /*boat_x=*/0.0, /*boat_y=*/0.0, /*stamp_s=*/100.0, acc_params());
-  ASSERT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), params.hit_log_odds, kLogOddsTol);
+  ASSERT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), kContact, kLogOddsTol);
 
   // Shift the window by 0.5 m (2 cells, parity preserved so (0,0) stays a cell
   // centre); (0,0) stays inside the 4.25 m window. Sky mask → zero observations,
@@ -162,7 +173,7 @@ TEST(AccumulateFrame, MovePreservesOverlappingEvidence)
     /*boat_x=*/0.5, /*boat_y=*/0.0, /*stamp_s=*/100.0, acc_params());
 
   EXPECT_EQ(applied, 0u) << "sky frame contributes no observations";
-  EXPECT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), params.hit_log_odds, kLogOddsTol)
+  EXPECT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), kContact, kLogOddsTol)
     << "move() must preserve the prior hit at its world position";
 }
 
@@ -182,14 +193,14 @@ TEST(AccumulateFrame, DecayAttenuatesPriorHitBetweenFrames)
   contact.at<cv::Vec3b>(6, 8) = cv::Vec3b(200, 0, 0);
   accumulate_frame(buffer, contact, model, kNadirOrigin, nadir_rotation(),
     0.0, 0.0, /*stamp_s=*/100.0, acc_params());
-  ASSERT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), params.hit_log_odds, kLogOddsTol);
+  ASSERT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), kContact, kLogOddsTol);
 
   // One half-life later, with no new observation at (0,0): value halves.
   accumulate_frame(buffer, all_sky(), model, kNadirOrigin, nadir_rotation(),
     0.0, 0.0, /*stamp_s=*/110.0, acc_params());
 
   EXPECT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)),
-    params.hit_log_odds * 0.5, 1e-3)
+    kContact * 0.5, 1e-3)
     << "decay() must attenuate prior evidence by the half-life factor before ingest";
 }
 
@@ -212,13 +223,13 @@ TEST(AccumulateFrame, DecayPrecedesFreshIngest)
   contact.at<cv::Vec3b>(6, 8) = cv::Vec3b(200, 0, 0);
   accumulate_frame(buffer, contact, model, kNadirOrigin, nadir_rotation(),
     0.0, 0.0, /*stamp_s=*/100.0, acc_params());
-  ASSERT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), params.hit_log_odds, kLogOddsTol);
+  ASSERT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)), kContact, kLogOddsTol);
 
   // Same contact, one half-life later: decay the prior hit, THEN add the fresh one.
   accumulate_frame(buffer, contact, model, kNadirOrigin, nadir_rotation(),
     0.0, 0.0, /*stamp_s=*/110.0, acc_params());
 
   EXPECT_NEAR(buffer.logOdds(grid_map::Position(0.0, 0.0)),
-    params.hit_log_odds * 0.5 + params.hit_log_odds, 1e-3)
+    kContact * 0.5 + kContact, 1e-3)
     << "fresh hit must be applied after decay, not decayed with the prior evidence";
 }

--- a/sea_surface_segmentation/test/test_occupancy_buffer.cpp
+++ b/sea_surface_segmentation/test/test_occupancy_buffer.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <limits>
 #include <string>
 
 #include <grid_map_core/grid_map_core.hpp>
@@ -66,6 +67,18 @@ TEST(OccupancyBuffer, ClampBoundsEvidence)
   EXPECT_NEAR(buf.logOdds(kP), 5.0, 1e-5) << "saturates at obstacle_clamp";
   for (int i = 0; i < 50; ++i) { buf.accumulate(kP, -100.0); }  // huge -increments
   EXPECT_NEAR(buf.logOdds(kP), -2.0, 1e-5) << "saturates at clear_floor";
+}
+
+// A non-finite increment must be a no-op, never stored — std::clamp would
+// propagate the NaN and turn an observed cell back into "unobserved", silently
+// dropping evidence.
+TEST(OccupancyBuffer, NonFiniteIncrementIsNoOp)
+{
+  auto buf = make_buffer();
+  ASSERT_TRUE(buf.accumulate(kP, 0.5));  // establish a finite value
+  EXPECT_FALSE(buf.accumulate(kP, std::nan("")));
+  EXPECT_FALSE(buf.accumulate(kP, std::numeric_limits<double>::infinity()));
+  EXPECT_NEAR(buf.logOdds(kP), 0.5, 1e-5) << "prior evidence preserved, not NaN";
 }
 
 // occupancyAt: unobserved is -1; small positive between free and lethal ramps

--- a/sea_surface_segmentation/test/test_occupancy_buffer.cpp
+++ b/sea_surface_segmentation/test/test_occupancy_buffer.cpp
@@ -200,6 +200,11 @@ TEST(OccupancyBuffer, ValidateRejectsBadParams)
 
   p = OccupancyParams{}; p.free_threshold = std::nan("");  // finite required
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
+
+  // clear_floor must be <= free_threshold, else fully-cleared water floors above
+  // free_threshold and publishes a positive (soft-obstacle) cost.
+  p = OccupancyParams{}; p.free_threshold = -3.0;  // below clear_floor (-2.0)
+  EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 }
 
 // setParams reinterprets accumulated evidence immediately — a single increment

--- a/sea_surface_segmentation/test/test_occupancy_buffer.cpp
+++ b/sea_surface_segmentation/test/test_occupancy_buffer.cpp
@@ -5,8 +5,10 @@
 
 #include <grid_map_core/grid_map_core.hpp>
 
+#include "sea_surface_segmentation/cost_mapping.hpp"
 #include "sea_surface_segmentation/occupancy_buffer.hpp"
 
+using sea_surface_segmentation::occupancy_to_cost;
 using sea_surface_segmentation::OccupancyBuffer;
 using sea_surface_segmentation::OccupancyParams;
 
@@ -21,49 +23,76 @@ OccupancyBuffer make_buffer(const OccupancyParams & p = OccupancyParams{})
 const grid_map::Position kP(0.3, 0.0);  // a representative observed cell
 }  // namespace
 
-// A single obstacle observation must NOT mark a cell lethal — this is the
-// flicker rejection that the per-frame-reset layer lacked (one stray
-// segmentation pixel shouldn't become an obstacle).
+// A single small positive increment must NOT mark a cell lethal — flicker
+// rejection: one marginal observation shouldn't read as a confirmed obstacle.
 TEST(OccupancyBuffer, SingleObservationBelowThreshold)
 {
-  auto buf = make_buffer();  // hit=0.85, threshold=1.0
-  EXPECT_TRUE(buf.hit(kP));
+  auto buf = make_buffer();  // lethal_threshold = 1.0
+  EXPECT_TRUE(buf.accumulate(kP, 0.85));
   EXPECT_NEAR(buf.logOdds(kP), 0.85, 1e-5);
   EXPECT_FALSE(buf.isLethal(kP)) << "one observation < threshold must not be lethal";
 }
 
-// Repeated observations accumulate past the threshold — the obstacle is
+// Repeated positive increments accumulate past the threshold — the obstacle is
 // remembered once it's confirmed.
 TEST(OccupancyBuffer, RepeatedObservationsCrossThreshold)
 {
   auto buf = make_buffer();
-  buf.hit(kP);
-  buf.hit(kP);
+  buf.accumulate(kP, 0.85);
+  buf.accumulate(kP, 0.85);
   EXPECT_NEAR(buf.logOdds(kP), 1.70, 1e-5);
   EXPECT_TRUE(buf.isLethal(kP));
 }
 
-// Free-space (water) observations drive an obstacle back below the threshold —
-// the layer can clear a stale mark when it sees water there.
+// Negative (water) increments drive an obstacle back below the threshold — the
+// layer can clear a stale mark when it sees water there.
 TEST(OccupancyBuffer, FreeObservationsClearObstacle)
 {
   auto buf = make_buffer();
-  buf.hit(kP); buf.hit(kP); buf.hit(kP);  // 2.55 → lethal
+  buf.accumulate(kP, 0.85); buf.accumulate(kP, 0.85); buf.accumulate(kP, 0.85);  // 2.55 → lethal
   ASSERT_TRUE(buf.isLethal(kP));
-  buf.miss(kP); buf.miss(kP); buf.miss(kP); buf.miss(kP);  // -1.6 → 0.95
+  buf.accumulate(kP, -0.40); buf.accumulate(kP, -0.40);
+  buf.accumulate(kP, -0.40); buf.accumulate(kP, -0.40);  // -1.6 → 0.95
   EXPECT_NEAR(buf.logOdds(kP), 0.95, 1e-5);
   EXPECT_FALSE(buf.isLethal(kP));
 }
 
-// Evidence is bounded so it stays revisable (no runaway saturation that would
-// take forever to clear).
+// Evidence is bounded to [clear_floor, obstacle_clamp] so it stays revisable
+// (no runaway saturation that would take forever to clear).
 TEST(OccupancyBuffer, ClampBoundsEvidence)
 {
-  auto buf = make_buffer();  // clamp = 5.0
-  for (int i = 0; i < 20; ++i) { buf.hit(kP); }
-  EXPECT_NEAR(buf.logOdds(kP), 5.0, 1e-5);
-  for (int i = 0; i < 40; ++i) { buf.miss(kP); }
-  EXPECT_NEAR(buf.logOdds(kP), -5.0, 1e-5);
+  auto buf = make_buffer();  // obstacle_clamp = 5.0, clear_floor = -2.0
+  for (int i = 0; i < 50; ++i) { buf.accumulate(kP, 100.0); }  // huge +increments
+  EXPECT_NEAR(buf.logOdds(kP), 5.0, 1e-5) << "saturates at obstacle_clamp";
+  for (int i = 0; i < 50; ++i) { buf.accumulate(kP, -100.0); }  // huge -increments
+  EXPECT_NEAR(buf.logOdds(kP), -2.0, 1e-5) << "saturates at clear_floor";
+}
+
+// occupancyAt: unobserved is -1; small positive between free and lethal ramps
+// 1..99; at/above lethal is 100; at/below free_threshold (e.g. negative) is -1.
+TEST(OccupancyBuffer, OccupancyAtRampAndBounds)
+{
+  auto buf = make_buffer();  // free_threshold=0, lethal_threshold=1.0
+
+  // Unobserved → -1.
+  EXPECT_EQ(buf.occupancyAt(kP), -1);
+
+  // Half-way up the ramp (0.5 of [0,1]) → ~50.
+  buf.accumulate(kP, 0.5);
+  const int mid = buf.occupancyAt(kP);
+  EXPECT_GE(mid, 1);
+  EXPECT_LE(mid, 99);
+  EXPECT_NEAR(mid, 50, 2) << "linear ramp should land near the midpoint";
+
+  // Push to/over lethal → 100.
+  buf.accumulate(kP, 1.0);  // total 1.5 >= 1.0
+  EXPECT_EQ(buf.occupancyAt(kP), 100);
+
+  // A purely negative (water) cell sits at/below free_threshold → -1.
+  const grid_map::Position kWater(0.3, 0.5);
+  buf.accumulate(kWater, -0.4);
+  EXPECT_EQ(buf.occupancyAt(kWater), -1)
+    << "<= free_threshold reads as no opinion (we only ADD cost)";
 }
 
 // A never-observed cell is unknown (NaN), not free and not lethal.
@@ -72,6 +101,7 @@ TEST(OccupancyBuffer, UnobservedCellIsUnknown)
   auto buf = make_buffer();
   EXPECT_TRUE(std::isnan(buf.logOdds(kP)));
   EXPECT_FALSE(buf.isLethal(kP));
+  EXPECT_EQ(buf.occupancyAt(kP), -1);
 }
 
 // "Remember, but not forever": a confirmed obstacle decays back below the
@@ -79,7 +109,7 @@ TEST(OccupancyBuffer, UnobservedCellIsUnknown)
 TEST(OccupancyBuffer, DecayForgetsObstacleOverTime)
 {
   auto buf = make_buffer();  // half-life 30 s
-  buf.hit(kP); buf.hit(kP);  // 1.70 → lethal
+  buf.accumulate(kP, 0.85); buf.accumulate(kP, 0.85);  // 1.70 → lethal
   buf.decay(0.0);            // first call only seeds the clock
   EXPECT_TRUE(buf.isLethal(kP)) << "no time elapsed yet";
   buf.decay(25.0);           // 1.70 * 0.5^(25/30) ≈ 0.954
@@ -95,7 +125,7 @@ TEST(OccupancyBuffer, DecayForgetsObstacleOverTime)
 TEST(OccupancyBuffer, BackwardTimeDoesNotDecayOrRewind)
 {
   auto buf = make_buffer();  // half-life 30 s
-  buf.hit(kP); buf.hit(kP);  // 1.70 → lethal
+  buf.accumulate(kP, 0.85); buf.accumulate(kP, 0.85);  // 1.70 → lethal
   buf.decay(100.0);          // seed reference at t=100
   buf.decay(50.0);           // backward: must not decay, must not rewind reference
   EXPECT_NEAR(buf.logOdds(kP), 1.70, 1e-5) << "backward time must not decay";
@@ -107,18 +137,13 @@ TEST(OccupancyBuffer, BackwardTimeDoesNotDecayOrRewind)
 
 // Rolling the window through a sequence of origin shifts must preserve
 // accumulated evidence at its true world cell (not drift it to a neighbour or
-// wipe it), and newly-exposed cells must read as unobserved. grid_map's move()
-// snaps each shift to whole cells and carries the sub-cell residual internally,
-// so this exercises no-drift-across-rolling + exposed-unobserved — the core of
-// review-plan must-fix #1 — rather than the residual arithmetic itself.
+// wipe it), and newly-exposed cells must read as unobserved.
 TEST(OccupancyBuffer, RollingPreservesEvidenceAtWorldCell)
 {
   auto buf = make_buffer();
-  buf.hit(kP); buf.hit(kP);  // lethal at world (0.3, 0)
+  buf.accumulate(kP, 0.85); buf.accumulate(kP, 0.85);  // lethal at world (0.3, 0)
   ASSERT_TRUE(buf.isLethal(kP));
 
-  // Roll the window through successive origin steps to an end center of
-  // (1.0, 0). kP stays inside the window throughout.
   buf.move(grid_map::Position(0.3, 0.0));
   buf.move(grid_map::Position(0.6, 0.0));
   buf.move(grid_map::Position(1.0, 0.0));
@@ -126,8 +151,6 @@ TEST(OccupancyBuffer, RollingPreservesEvidenceAtWorldCell)
   EXPECT_TRUE(buf.isLethal(kP))
     << "evidence must survive fractional rolling at its world location";
 
-  // A cell that was outside the original window (|x|<=2) but inside the rolled
-  // one (x in [-1,3]) must be unobserved, not lethal.
   const grid_map::Position exposed(2.5, 0.0);
   EXPECT_TRUE(std::isnan(buf.logOdds(exposed)));
   EXPECT_FALSE(buf.isLethal(exposed));
@@ -138,8 +161,9 @@ TEST(OccupancyBuffer, OutOfBoundsObservationIsNoOp)
 {
   auto buf = make_buffer();
   const grid_map::Position outside(100.0, 100.0);
-  EXPECT_FALSE(buf.hit(outside));
+  EXPECT_FALSE(buf.accumulate(outside, 0.85));
   EXPECT_FALSE(buf.isLethal(outside));
+  EXPECT_EQ(buf.occupancyAt(outside), -1);
 }
 
 // Parameter validation rejects values that would corrupt the buffer's meaning —
@@ -150,37 +174,41 @@ TEST(OccupancyBuffer, ValidateRejectsBadParams)
   EXPECT_TRUE(OccupancyBuffer::validate(OccupancyParams{}, why)) << why;
 
   OccupancyParams p;
-  p.hit_log_odds = -1.0;  // must be > 0
+  p.obstacle_clamp = -1.0;  // must be > 0
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 
-  p = OccupancyParams{}; p.miss_log_odds = 0.5;  // must be < 0
+  p = OccupancyParams{}; p.clear_floor = 0.5;  // must be < 0
+  EXPECT_FALSE(OccupancyBuffer::validate(p, why));
+
+  p = OccupancyParams{}; p.clear_floor = 0.0;  // must be strictly < 0
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 
   p = OccupancyParams{}; p.decay_half_life_s = 0.0;  // must be > 0
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 
-  p = OccupancyParams{}; p.lethal_threshold = 99.0;  // must be <= clamp
+  p = OccupancyParams{}; p.lethal_threshold = 99.0;  // must be <= obstacle_clamp
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 
-  p = OccupancyParams{}; p.lethal_threshold = 0.0;   // must be > 0 (else 1 hit = lethal)
+  p = OccupancyParams{}; p.free_threshold = 1.0; p.lethal_threshold = 1.0;  // free < lethal
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 
-  p = OccupancyParams{}; p.lethal_threshold = -1.0;  // negative inverts safety (water => lethal)
+  p = OccupancyParams{}; p.free_threshold = 2.0;  // free >= lethal (1.0)
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 
-  p = OccupancyParams{}; p.hit_log_odds = std::nan("");  // finite required
+  p = OccupancyParams{}; p.obstacle_clamp = std::nan("");  // finite required
+  EXPECT_FALSE(OccupancyBuffer::validate(p, why));
+
+  p = OccupancyParams{}; p.free_threshold = std::nan("");  // finite required
   EXPECT_FALSE(OccupancyBuffer::validate(p, why));
 }
 
-// setParams reinterprets accumulated evidence immediately — a single hit that
-// sat just under the default lethal_threshold (1.0) becomes lethal once a
+// setParams reinterprets accumulated evidence immediately — a single increment
+// that sat just under the default lethal_threshold (1.0) becomes lethal once a
 // lower threshold (0.3) is applied at runtime, without re-observing the cell.
-// This is the live-tunable contract the layer's param callback relies on
-// (`SeaSurfaceLayer::onParametersSet` → `OccupancyBuffer::setParams`).
 TEST(OccupancyBuffer, SetParamsReinterpretsAccumulatedEvidence)
 {
-  auto buf = make_buffer();  // defaults: hit=0.85, threshold=1.0
-  EXPECT_TRUE(buf.hit(kP));
+  auto buf = make_buffer();  // defaults: lethal_threshold = 1.0
+  EXPECT_TRUE(buf.accumulate(kP, 0.85));
   EXPECT_FALSE(buf.isLethal(kP)) << "0.85 < 1.0, not yet lethal at default threshold";
 
   OccupancyParams looser = OccupancyParams{};
@@ -191,4 +219,23 @@ TEST(OccupancyBuffer, SetParamsReinterpretsAccumulatedEvidence)
 
   EXPECT_TRUE(buf.isLethal(kP))
     << "lowered threshold must reinterpret accumulated 0.85 log-odds as lethal";
+}
+
+// occupancy_to_cost boundaries: -1/0 → -1 (untouched); 1 → 1; 99 → 252 (below
+// INSCRIBED 253); 100 → LETHAL_OBSTACLE (254).
+TEST(CostMapping, OccupancyToCostBoundaries)
+{
+  EXPECT_EQ(occupancy_to_cost(-1), -1);
+  EXPECT_EQ(occupancy_to_cost(0), -1);
+  EXPECT_EQ(occupancy_to_cost(1), 1);
+  EXPECT_EQ(occupancy_to_cost(99), 252);
+  EXPECT_EQ(occupancy_to_cost(100), 254);  // LETHAL_OBSTACLE
+  // Monotonic across the soft ramp, and never reaching INSCRIBED (253).
+  int prev = 0;
+  for (int occ = 1; occ <= 99; ++occ) {
+    const int c = occupancy_to_cost(occ);
+    EXPECT_GE(c, prev);
+    EXPECT_LE(c, 252) << "soft cost must stay below INSCRIBED_INFLATED_OBSTACLE (253)";
+    prev = c;
+  }
 }

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -14,6 +14,7 @@
 
 #include "sea_surface_segmentation/segments_projection.hpp"
 
+using sea_surface_segmentation::pixel_log_odds;
 using sea_surface_segmentation::is_obstacle_pixel;
 using sea_surface_segmentation::is_waterline_contact_pixel;
 using sea_surface_segmentation::project_observations;
@@ -102,6 +103,24 @@ constexpr double kRangeTolerance = 0.05;  // 5 cm — projection should be tight
 constexpr double kLateralTolerance = 0.05;
 
 }  // namespace
+
+// pixel_log_odds: graded evidence + defensive guards for the exported utility.
+TEST(PixelLogOdds, GradedAndDefensive)
+{
+  // Prior-shifted: zero-crossing at obstacle_prob_min, positive above, capped.
+  EXPECT_NEAR(pixel_log_odds(200, 0.35, 0.85), 0.85, 1e-9) << "confident → capped +";
+  EXPECT_LT(pixel_log_odds(20, 0.35, 0.85), 0.0) << "open water → negative";
+  EXPECT_GT(pixel_log_odds(120, 0.35, 0.85), 0.0) << "P_obs=0.47 > prob_min → still positive";
+  // Defensive: out-of-range R is clamped, never NaN/Inf.
+  EXPECT_TRUE(std::isfinite(pixel_log_odds(-5, 0.35, 0.85)));
+  EXPECT_TRUE(std::isfinite(pixel_log_odds(300, 0.35, 0.85)));
+  // Invalid params → 0.0 (no opinion), never NaN/Inf/UB.
+  EXPECT_EQ(pixel_log_odds(200, 0.0, 0.85), 0.0) << "prob_min=0 → no opinion";
+  EXPECT_EQ(pixel_log_odds(200, 1.0, 0.85), 0.0) << "prob_min=1 → no opinion";
+  EXPECT_EQ(pixel_log_odds(200, std::nan(""), 0.85), 0.0);
+  EXPECT_EQ(pixel_log_odds(200, 0.35, 0.0), 0.0) << "max_step<=0 → no opinion (no clamp UB)";
+  EXPECT_EQ(pixel_log_odds(200, 0.35, -1.0), 0.0);
+}
 
 // is_obstacle_pixel: red-dominant in, neutral/green/blue out.
 TEST(IsObstaclePixel, RedDominantTrue)

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -535,6 +535,10 @@ TEST(ProjectObservationsInverse, AllWaterAllMisses)
   auto [obstacle, free] = count_obs(obs);
   EXPECT_EQ(obstacle, 0);
   EXPECT_GT(free, 0) << "every in-footprint cell should be classified as water-miss";
+  // Graded evidence: every water observation carries a negative log-odds.
+  for (const auto & o : obs) {
+    EXPECT_LT(o.log_odds, 0.0) << "water (R=0) must yield negative graded evidence";
+  }
 }
 
 // All-sky mask → every cell projects to a sky pixel → SKIP (no obs), not miss.
@@ -567,6 +571,14 @@ TEST(ProjectObservationsInverse, ContactCellHitsBodyCellsSkipped)
   // obstacle there. Verify by ensuring obstacle count is bounded — the contact
   // is one pixel, so only cells projecting to that one pixel become hits.
   EXPECT_LE(obstacle, 4) << "only the contact-pixel's cell footprint is hit, not the body's";
+  // Graded evidence sign: obstacle observations are positive, water negative.
+  for (const auto & o : obs) {
+    if (o.obstacle) {
+      EXPECT_GT(o.log_odds, 0.0) << "contact (R=200) must yield positive graded evidence";
+    } else {
+      EXPECT_LT(o.log_odds, 0.0) << "water (R=0) must yield negative graded evidence";
+    }
+  }
 }
 
 // Cells beyond max_range (even when in-image) are dropped by the Euclidean


### PR DESCRIPTION
Closes #22

# Plan: sea_surface marking + costmap dynamics — accumulate per-pixel softmax log-odds

## Issue

https://github.com/rolker/unh_marine_perception/issues/22

## Context

The segmentation mask is a per-pixel **softmax** scaled to 255
(`sea_surface_segmentation.cpp:124–131`): `R=255·P(obstacle)`, `G=255·P(water)`,
`B=255·P(sky)`, `R+G+B=255`. The costmap discards this graded confidence: a strict
argmax gate (`segments_projection.hpp:44`) feeds a flat `hit(+0.85)`/`miss(−0.40)`
into the log-odds buffer. Marginal-red obstacles are scored as confident water and
*erode* accumulated evidence (never register — the #186 operator bug), and the
symmetric ±5 clamp over-damps recovery once a cell has saturated to water.

Fix: stop collapsing the softmax. Feed the buffer the real per-pixel occupancy
log-odds (prior-shifted at `obstacle_prob_min`; see Implementation Notes), bound
recovery with an asymmetric clamp, and emit a graded cost ramp instead of binary
lethal. Single PR; all knobs runtime-tunable.

## Approach (single PR — implemented)

Per the 2026-05-29 discussion: **one PR**, **graded cost output** (not binary),
**all knobs runtime-tunable** for on-water tuning, and the **reflex/Collision-Monitor
path left untouched** (it is known-good; the #186 bug is costmap-only).

1. **Graded per-observation evidence** — `OccupancyObservation` gains a signed
   `double log_odds` (additive; keeps `obstacle` for the #23 shared API). A new
   `pixel_log_odds(R, obstacle_prob_min, max_evidence_step)` returns a
   **prior-shifted, capped logit** of the red channel:
   `clamp(log((R+ε)/(255−R+ε)) − log(prob_min/(1−prob_min)), ±max_step)`.
   The prior shift puts the zero-crossing at `obstacle_prob_min` (not 0.5), so a
   buoy where water is marginally more likely (`P_obs > prob_min`) still banks
   **positive** evidence — the actual #186 fix. Defaults: R=200→+0.85, R=120→+0.50,
   R=20→−0.85.
2. **Graded gate (costmap path only)** — `project_observations_inverse` replaces
   the argmax `is_obstacle_pixel`/`is_waterline_contact_pixel` with
   `is_obstacle_ish(px) = R ≥ obstacle_prob_min·255` (same waterline-contact
   geometry), and emits `log_odds` for contact (+) and green-water (−) cells; sky
   /ambiguous still skipped.
3. **Buffer accumulates the signed increment** — `OccupancyBuffer::accumulate(pos,
   log_odds)` (replaces `hit()/miss()`), clamped to **asymmetric**
   `[clear_floor=−2, obstacle_clamp=+5]` (recovery cleared→lethal ~8→~4 frames).
4. **Graded occupancy + cost** — `occupancyAt()` maps log-odds to `−1` (no opinion:
   unobserved or ≤`free_threshold`) / `1…99` ramp / `100` (≥`lethal_threshold`).
   New `cost_mapping.hpp::occupancy_to_cost()` maps that to nav2 cost: `−1`
   (untouched) / soft `1…252` / `LETHAL=254` (stays below `INSCRIBED=253`).
5. **Graded output everywhere** — layer `updateCosts` stamps the ramp; the layer
   publishes the graded occupancy grid; `SeaSurfaceRelayLayer` forwards the full
   gradient (not just `≥100`). Both still only **ADD** (no-opinion never clears).
6. **All params runtime-tunable** — `obstacle_prob_min`, `max_evidence_step`,
   `obstacle_clamp`, `clear_floor`, `free_threshold`, `lethal_threshold`,
   `decay_half_life_s` validate-then-apply via `onParametersSet`.
7. **Tests** — buffer accumulate/`occupancyAt`/`validate`; `cost_mapping`
   boundaries; graded accumulator expectations; projection log-odds signs.
   **69 tests pass.**

## Files Changed

| File | Change |
|------|--------|
| `include/.../segments_projection.hpp` | `OccupancyObservation.log_odds`; `pixel_log_odds()`; graded gate in `project_observations_inverse` (argmax predicates kept for the reflex/forward paths) |
| `include/.../occupancy_buffer.hpp` | `accumulate()`; asymmetric clamp params; `occupancyAt()`; reworked `validate()`; snapshot ctor for off-lock publish |
| `include/.../cost_mapping.hpp` (NEW) | `occupancy_to_cost()` — the one nav2-cost mapping, shared by layer + relay |
| `include/.../occupancy_accumulator.hpp` | `AccumulateParams` gains `obstacle_prob_min`/`max_evidence_step`; uses `accumulate()` |
| `src/sea_surface_layer.cpp` | new param block + live snapshot; graded `updateCosts`; graded publish; `onParametersSet` |
| `src/sea_surface_relay_layer.cpp` | forward the full graded gradient via `occupancy_to_cost` |
| `config/README.md` | param table + behavior for both layers |
| `CMakeLists.txt`, `test/*` | `cost_mapping` link; updated/added tests |

_Not changed (intentionally): `src/segments_to_pointcloud.cpp` and the argmax
predicates — the reflex Collision-Monitor path is known-good and out of scope._

## Principles Self-Check

| Principle | Consideration |
|---|---|
| A change includes its consequences | Relay gradient, `OccupancyObservation` consumers (#23 offline core), config docs, tests all in plan |
| Only what's needed | Two-timescale rebuild rejected (reflex owns dynamics); reflex-gate change dropped (CA known-good); graded output kept (user wants varying cost) |
| Test what breaks | Log-odds tails (ε guard), asymmetric clamp, ramp boundaries, water-negative, cost-mapping boundaries — all unit-tested (69 pass) |
| Improve incrementally | Single PR by user direction (test window); knobs runtime-tunable so behavior is refined on-water rather than across PRs |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0008 ROS2 conventions | Yes | New params declared/validated; costmap value semantics (252 vs 253 inscribed / 254 lethal) respected |
| 0013 progress.md vocabulary | Yes | Plan-authored entry appended |
| 0011 field mode | No | Repo origin is github.com (dev mode) |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| `OccupancyObservation` struct | #23 offline bag→costmap core (consumes it — PR #24 open) | Yes — additive field; coordinate sequencing |
| flat hit/miss → increment | tests asserting fixed ±0.85/−0.40 | Yes — accumulator/buffer tests updated to graded values |
| binary lethal → graded ramp | relay (was `≥100`), global planner cost weights, inflation ordering | Relay + layer emit the gradient; **planner `cost_penalty`/`CostCritic` live in the echoboats/seafloor nav2 config repo — soft costs are inert for routing until set there** (see Open Questions) |

## Open Questions

- **Planner cost weighting (separate repo)** — the graded ramp only biases routing
  if `SmacPlannerHybrid.cost_penalty` / MPPI `CostCritic` are tuned in the
  echoboats/seafloor nav2 config. Until then the gradient is visible (rviz) and the
  controller may honor it, but global routing won't. Follow-up config task.
- **On-water tuning** — defaults (`obstacle_prob_min=0.35`, `max_evidence_step=0.85`,
  `clear_floor=−2`, `free_threshold=0`, `lethal_threshold=1`) are provisional; all
  are runtime-reconfigurable. Tune `obstacle_prob_min` first (dim-buoy sensitivity)
  against the #186 bag / live segmentation.
- **#23 coordination** — `OccupancyObservation` gained a field (additive); coordinate
  with the in-flight offline-core export (PR #24) on merge order.

## Estimated Scope

Single PR (#25), implemented. Follow-up: planner-side cost-weight config in the
echoboats/seafloor nav2 repo to activate soft-cost routing.

## Implementation Notes

- **Prior-shifted logit, not plain `log(R/(255−R))`.** The original plan/issue used
  the unshifted logit (zero-crossing at P=0.5). That would still drop a buoy whose
  pixels are red-present-but-water-dominant (`G > R`, i.e. `P_obs < 0.5`) — the
  exact #186 case. Shifting the zero-crossing to `obstacle_prob_min` lets such
  pixels bank positive evidence, and makes `obstacle_prob_min` the headline
  on-water sensitivity knob. `max_evidence_step` caps a single frame (flicker
  rejection; ~2 frames to lethal at defaults).
- **Off-lock graded publish** uses a read-only `OccupancyBuffer` snapshot ctor so
  `occupancyAt` remains the single source of the ramp (no duplicate mapping).
