### PR TITLE
Field import (2026-05-29) + max-pool fix for the costmap marking gap (#26)

### DIFF
--- a/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
@@ -473,6 +473,49 @@ inline std::vector<OccupancyObservation> project_observations_inverse(
       // else: sky (blue-dominant) or ambiguous → skip (no observation)
     }
   }
+
+  // Per-column contact backstop: the cell loop above only marks cells whose
+  // (rounded) projection lands exactly on contact_row[u]. At close range the
+  // angular resolution dwarfs the cell-grid step — few or zero cells round to
+  // the exact contact pixel, so a clearly-detected close buoy can produce no
+  // marks at all. This pass back-projects each detected contact pixel directly
+  // to z = plane_z and pushes one observation at the contact's true world
+  // position. The mark lands AT the obstacle's footprint (not the body
+  // back-projected past it), so no radial false shadow is introduced. Same
+  // range / grazing gates as the cell loop.
+  const double cam_z = camera_origin[2];
+  for (int col = 0; col < mask_rgb8.cols; ++col) {
+    const int crow = contact_row[col];
+    if (crow < 0) { continue; }
+
+    const cv::Point2d cpixel(col, crow);
+    const cv::Point3d ray_cam = camera_model.projectPixelTo3dRay(cpixel);
+    const cv::Vec3d ray_target =
+      rotation_cam_to_target * cv::Vec3d(ray_cam.x, ray_cam.y, ray_cam.z);
+    if (!std::isfinite(ray_target[2]) || ray_target[2] == 0.0) { continue; }
+    const double u_param = (plane_z - cam_z) / ray_target[2];
+    if (!std::isfinite(u_param) || u_param <= 0.0) { continue; }
+
+    const double wxc = camera_origin[0] + u_param * ray_target[0];
+    const double wyc = camera_origin[1] + u_param * ray_target[1];
+    if (!std::isfinite(wxc) || !std::isfinite(wyc)) { continue; }
+
+    const double dx = wxc - camera_origin[0];
+    const double dy = wyc - camera_origin[1];
+    const double range_sq_xy = dx * dx + dy * dy;
+    if (range_sq_xy > max_range * max_range) { continue; }
+    if (min_grazing_sin > 0.0) {
+      const double dz = plane_z - cam_z;
+      const double range_sq_full = range_sq_xy + dz * dz;
+      if (dz * dz < min_grazing_sin_sq * range_sq_full) { continue; }
+    }
+
+    const cv::Vec3b cpx = mask_rgb8.at<cv::Vec3b>(crow, col);
+    observations.push_back(
+      {wxc, wyc, true,
+       pixel_log_odds(cpx[0], obstacle_prob_min, max_evidence_step)});
+  }
+
   return observations;
 }
 

--- a/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <unordered_map>
 #include <vector>
 
 #include <opencv2/core.hpp>
@@ -399,7 +400,8 @@ inline std::vector<OccupancyObservation> project_observations_inverse(
   double plane_z = 0.0,
   double min_grazing_angle_deg = 0.0,
   double obstacle_prob_min = 0.5,
-  double max_evidence_step = 0.85)
+  double max_evidence_step = 0.85,
+  bool max_pool_bins = true)
 {
   // Graded obstacle gate: a pixel counts as obstacle-ish when its red channel
   // (255·P(obstacle)) implies P(obstacle) >= obstacle_prob_min. Replaces the
@@ -516,7 +518,41 @@ inline std::vector<OccupancyObservation> project_observations_inverse(
        pixel_log_odds(cpx[0], obstacle_prob_min, max_evidence_step)});
   }
 
-  return observations;
+  // Max-pool to one observation per accumulator cell (#26). The forward backstop
+  // above emits a contact's obstacle evidence at its true footprint, but the
+  // inverse cell loop also emits a WATER (free) observation for the cell whose
+  // centre-ray sampled adjacent water — and the downstream buffer accumulates
+  // every observation ADDITIVELY, so a small obstacle's single contact is washed
+  // out by the co-located water and the cell nets free. Collapsing each cell to
+  // its MAX (obstacle-preferring: obstacle log-odds are +ve, water -ve) lets the
+  // contact override the co-located water instead of cancelling against it, so a
+  // faint-but-real buoy marks without lowering the global obstacle threshold.
+  // Cells with only water still emit free; free coverage is unchanged.
+  // Gated for A/B + on-water rollback.
+  if (!max_pool_bins) {
+    return observations;
+  }
+  std::unordered_map<int64_t, double> bin_log_odds;
+  bin_log_odds.reserve(observations.size());
+  for (const auto & o : observations) {
+    const int ix = static_cast<int>(std::lround((o.x - cx) / res)) + n / 2;
+    const int iy = static_cast<int>(std::lround((o.y - cy) / res)) + n / 2;
+    if (ix < 0 || ix >= n || iy < 0 || iy >= n) { continue; }
+    const int64_t key = static_cast<int64_t>(iy) * n + ix;
+    auto it = bin_log_odds.find(key);
+    if (it == bin_log_odds.end() || o.log_odds > it->second) {
+      bin_log_odds[key] = o.log_odds;
+    }
+  }
+  std::vector<OccupancyObservation> pooled;
+  pooled.reserve(bin_log_odds.size());
+  for (const auto & kv : bin_log_odds) {
+    const int ix = static_cast<int>(kv.first % n);
+    const int iy = static_cast<int>(kv.first / n);
+    pooled.push_back(
+      {cx + (ix - n / 2) * res, cy + (iy - n / 2) * res, kv.second > 0.0, kv.second});
+  }
+  return pooled;
 }
 
 }  // namespace sea_surface_segmentation

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -115,6 +115,8 @@ public:
     node->get_parameter(name_ + ".obstacle_prob_min", obstacle_prob_min_);
     declareParameter("max_evidence_step", rclcpp::ParameterValue(max_evidence_step_));
     node->get_parameter(name_ + ".max_evidence_step", max_evidence_step_);
+    declareParameter("max_pool_bins", rclcpp::ParameterValue(max_pool_bins_));
+    node->get_parameter(name_ + ".max_pool_bins", max_pool_bins_);
 
     // Validate the projection knobs at startup (they live on the layer, not in
     // OccupancyParams, so OccupancyBuffer::validate below doesn't cover them).
@@ -465,6 +467,7 @@ private:
     double min_grazing_deg;
     double obstacle_prob_min;
     double max_evidence_step;
+    bool max_pool_bins;
     std::vector<cv::Rect> mask_rects;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
@@ -474,6 +477,7 @@ private:
       min_grazing_deg = min_grazing_angle_deg_;
       obstacle_prob_min = obstacle_prob_min_;
       max_evidence_step = max_evidence_step_;
+      max_pool_bins = max_pool_bins_;
       mask_rects = src.image_mask_rects;
     }
     if (!camera_model || res <= 0.0) {
@@ -530,7 +534,8 @@ private:
       const auto observations = sea_surface_segmentation::project_observations_inverse(
         seg_image, *camera_model, camera_origin, rotation_cam_to_world,
         maximum_range, camera_origin[0], camera_origin[1], res, maximum_range,
-        /*plane_z=*/0.0, min_grazing_deg, obstacle_prob_min, max_evidence_step);
+        /*plane_z=*/0.0, min_grazing_deg, obstacle_prob_min, max_evidence_step,
+        max_pool_bins);
 
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       if (!buffer_) {
@@ -672,6 +677,7 @@ private:
     double candidate_min_grazing_deg;
     double candidate_obstacle_prob_min;
     double candidate_max_evidence_step;
+    bool candidate_max_pool_bins;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       candidate_occ = params_;
@@ -679,6 +685,7 @@ private:
       candidate_min_grazing_deg = min_grazing_angle_deg_;
       candidate_obstacle_prob_min = obstacle_prob_min_;
       candidate_max_evidence_step = max_evidence_step_;
+      candidate_max_pool_bins = max_pool_bins_;
     }
     // Per-source mask candidates: validated below, applied at the end under
     // the same lock that swaps the scalar candidates. Keyed by Source* so a
@@ -752,6 +759,8 @@ private:
             return result;
           }
           candidate_max_evidence_step = v;
+        } else if (n == name_ + ".max_pool_bins") {
+          candidate_max_pool_bins = p.as_bool();
         } else if (n == name_ + ".maximum_range") {
           const double v = p.as_double();
           if (!std::isfinite(v) || v <= 0.0) {
@@ -810,6 +819,7 @@ private:
     min_grazing_angle_deg_ = candidate_min_grazing_deg;
     obstacle_prob_min_ = candidate_obstacle_prob_min;
     max_evidence_step_ = candidate_max_evidence_step;
+    max_pool_bins_ = candidate_max_pool_bins;
     for (auto & kv : candidate_mask_updates) {
       kv.first->image_mask_rects = std::move(kv.second);
     }
@@ -834,6 +844,10 @@ private:
   // Graded evidence-model knobs (live-tunable; snapshotted per segmentsCallback).
   double obstacle_prob_min_ = 0.35;
   double max_evidence_step_ = 0.85;
+  // #26: collapse each frame's projected observations to one-per-cell by max
+  // (obstacle-preferring) so a small obstacle's forward-projected contact is not
+  // diluted to free by co-located inverse water. Live-toggleable for on-water A/B.
+  bool max_pool_bins_ = true;
   sea_surface_segmentation::OccupancyParams params_;
   std::unique_ptr<sea_surface_segmentation::OccupancyBuffer> buffer_;
 

--- a/sea_surface_segmentation/src/sea_surface_layer.cpp
+++ b/sea_surface_segmentation/src/sea_surface_layer.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "cv_bridge/cv_bridge.hpp"
@@ -59,6 +60,12 @@ private:
     rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr seg_sub;
     rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr info_sub;
     std::shared_ptr<image_geometry::PinholeCameraModel> camera_model;
+    // Pixel-space rectangles to mask out before projection — e.g. on-boat
+    // structures (GPS antenna, hull) that consistently sit in this camera's
+    // FOV and would otherwise back-project to false near-boat marks. Written
+    // by the param callback under costmap_mutex_; snapshotted by
+    // segmentsCallback under the same lock.
+    std::vector<cv::Rect> image_mask_rects;
   };
 
 public:
@@ -161,10 +168,26 @@ public:
       for (const auto & name : source_names) {
         declareParameter(name + ".segmentation_topic", rclcpp::ParameterValue(std::string{}));
         declareParameter(name + ".camera_info_topic", rclcpp::ParameterValue(std::string{}));
+        // Pixel-space masks for this source (e.g. on-boat structures). Flat
+        // int array of [x_min, y_min, x_max, y_max] tuples; empty = no mask.
+        // Runtime-tunable via `ros2 param set <node> <layer>.<source>.image_mask_rects`.
+        declareParameter(
+          name + ".image_mask_rects",
+          rclcpp::ParameterValue(std::vector<int64_t>{}));
         auto src = std::make_unique<Source>();
         src->name = name;
         node->get_parameter(name_ + "." + name + ".segmentation_topic", src->segmentation_topic);
         node->get_parameter(name_ + "." + name + ".camera_info_topic", src->camera_info_topic);
+        std::vector<int64_t> mask_flat;
+        node->get_parameter(name_ + "." + name + ".image_mask_rects", mask_flat);
+        std::string mask_why;
+        if (!parseMaskRects(mask_flat, src->image_mask_rects, mask_why)) {
+          RCLCPP_WARN_STREAM(
+            logger_,
+            "SeaSurfaceLayer source '" << name << "' image_mask_rects invalid ("
+              << mask_why << "); ignoring masks for this source");
+          src->image_mask_rects.clear();
+        }
         if (src->segmentation_topic.empty() || src->camera_info_topic.empty()) {
           RCLCPP_ERROR_STREAM(
             logger_,
@@ -388,6 +411,41 @@ private:
       parent->getOriginY() + parent->getSizeInCellsY() * parent->getResolution() / 2.0);
   }
 
+  // Parse a flat int array of [x_min, y_min, x_max, y_max] tuples into
+  // cv::Rect's (each rect's width/height = x_max - x_min / y_max - y_min).
+  // The parameter is intentionally a flat int array because rclcpp doesn't
+  // expose nested-list types; every 4 entries is one rectangle. Returns
+  // true on success and populates `out`; returns false and writes a reason
+  // into `why` on any validation failure (image bounds are NOT validated
+  // here — the layer doesn't know image dimensions at init time, so masks
+  // are clipped to image bounds at apply time in segmentsCallback).
+  static bool parseMaskRects(
+    const std::vector<int64_t> & flat,
+    std::vector<cv::Rect> & out,
+    std::string & why)
+  {
+    if (flat.size() % 4 != 0) {
+      why = "image_mask_rects must have a multiple of 4 ints "
+        "(x_min, y_min, x_max, y_max per rectangle)";
+      return false;
+    }
+    out.clear();
+    out.reserve(flat.size() / 4);
+    for (size_t i = 0; i < flat.size(); i += 4) {
+      const int x_min = static_cast<int>(flat[i]);
+      const int y_min = static_cast<int>(flat[i + 1]);
+      const int x_max = static_cast<int>(flat[i + 2]);
+      const int y_max = static_cast<int>(flat[i + 3]);
+      if (x_min < 0 || y_min < 0 || x_max <= x_min || y_max <= y_min) {
+        why = "image_mask_rects entry must satisfy 0 <= x_min < x_max and "
+          "0 <= y_min < y_max";
+        return false;
+      }
+      out.emplace_back(x_min, y_min, x_max - x_min, y_max - y_min);
+    }
+    return true;
+  }
+
   // Per-source segmentation callback. `src` is the source that owns this
   // subscription (captured by raw pointer in onInitialize's lambda); the
   // shared occupancy buffer accumulates evidence from every source's hits and
@@ -407,6 +465,7 @@ private:
     double min_grazing_deg;
     double obstacle_prob_min;
     double max_evidence_step;
+    std::vector<cv::Rect> mask_rects;
     {
       std::lock_guard<std::mutex> lock(costmap_mutex_);
       camera_model = src.camera_model;
@@ -415,6 +474,7 @@ private:
       min_grazing_deg = min_grazing_angle_deg_;
       obstacle_prob_min = obstacle_prob_min_;
       max_evidence_step = max_evidence_step_;
+      mask_rects = src.image_mask_rects;
     }
     if (!camera_model || res <= 0.0) {
       return;
@@ -425,7 +485,27 @@ private:
       const auto tf = tf_->lookupTransform(
         global_frame_id_, segments_msg->header.frame_id, segments_msg->header.stamp,
         std::chrono::seconds(1));
-      const auto image = cv_bridge::toCvShare(segments_msg, "rgb8");
+      // If this source has pixel-space masks (on-boat structures etc.), deep-
+      // copy the image and black out the masked rectangles before projection
+      // — black pixels fail both is_obstacle_ish (R near 0) and the green-
+      // dominant water check, so they contribute no observations. Rectangles
+      // are clipped to image bounds here (image dimensions weren't known at
+      // param-set time). When no masks are configured, use the cheap zero-copy
+      // toCvShare path so the common case isn't penalised.
+      cv::Mat seg_image;
+      if (mask_rects.empty()) {
+        seg_image = cv_bridge::toCvShare(segments_msg, "rgb8")->image;
+      } else {
+        auto image_copy = cv_bridge::toCvCopy(segments_msg, "rgb8");
+        const cv::Rect full(0, 0, image_copy->image.cols, image_copy->image.rows);
+        for (const auto & r : mask_rects) {
+          const cv::Rect clipped = r & full;
+          if (clipped.area() > 0) {
+            image_copy->image(clipped).setTo(cv::Vec3b(0, 0, 0));
+          }
+        }
+        seg_image = image_copy->image;
+      }
 
       const auto & t = tf.transform.translation;
       const auto & q = tf.transform.rotation;
@@ -448,7 +528,7 @@ private:
       // model's image bounds + the camera pose) would prune those before
       // projection — meaningful CPU once we sustain N>1 cameras (phase 4).
       const auto observations = sea_surface_segmentation::project_observations_inverse(
-        image->image, *camera_model, camera_origin, rotation_cam_to_world,
+        seg_image, *camera_model, camera_origin, rotation_cam_to_world,
         maximum_range, camera_origin[0], camera_origin[1], res, maximum_range,
         /*plane_z=*/0.0, min_grazing_deg, obstacle_prob_min, max_evidence_step);
 
@@ -600,6 +680,10 @@ private:
       candidate_obstacle_prob_min = obstacle_prob_min_;
       candidate_max_evidence_step = max_evidence_step_;
     }
+    // Per-source mask candidates: validated below, applied at the end under
+    // the same lock that swaps the scalar candidates. Keyed by Source* so a
+    // batched set targeting two sources in one call is atomic.
+    std::unordered_map<Source *, std::vector<cv::Rect>> candidate_mask_updates;
 
     // Configure-time params — subscriber re-bind / publisher re-bind isn't
     // supported here, so accepting these silently would leave the parameter
@@ -684,6 +768,27 @@ private:
             return result;
           }
           candidate_min_grazing_deg = v;
+        } else {
+          // Per-source pixel-space mask: <layer>.<source_name>.image_mask_rects.
+          // Match by suffix, then resolve the middle segment to a known source.
+          const std::string mask_suffix = ".image_mask_rects";
+          if (n.size() > mask_suffix.size() &&
+            n.compare(n.size() - mask_suffix.size(), mask_suffix.size(), mask_suffix) == 0)
+          {
+            for (const auto & src_uptr : sources_) {
+              if (n == name_ + "." + src_uptr->name + mask_suffix) {
+                std::vector<cv::Rect> rects;
+                std::string why_mask;
+                if (!parseMaskRects(p.as_integer_array(), rects, why_mask)) {
+                  result.successful = false;
+                  result.reason = why_mask;
+                  return result;
+                }
+                candidate_mask_updates[src_uptr.get()] = std::move(rects);
+                break;
+              }
+            }
+          }
         }
       }
     } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
@@ -705,6 +810,9 @@ private:
     min_grazing_angle_deg_ = candidate_min_grazing_deg;
     obstacle_prob_min_ = candidate_obstacle_prob_min;
     max_evidence_step_ = candidate_max_evidence_step;
+    for (auto & kv : candidate_mask_updates) {
+      kv.first->image_mask_rects = std::move(kv.second);
+    }
     if (buffer_) {
       buffer_->setParams(params_);
     }

--- a/sea_surface_segmentation/src/sea_surface_segmentation.cpp
+++ b/sea_surface_segmentation/src/sea_surface_segmentation.cpp
@@ -51,7 +51,44 @@ public:
         auto calibration_handler = device_->readCalibration();
 
         segmentation_converter_ = std::make_shared<dai::rosBridge::ImageConverter>(frame_id_, true);
-        segmentation_camera_info_ = segmentation_converter_->calibrationToCameraInfo(calibration_handler, dai::CameraBoardSocket::CAM_A, 128, 96);
+        // The published segmentation image is 128x96 (NN output), but the actual
+        // pipeline is: camera preview at (params.preview_width x params.preview_height,
+        // typically 1280x720, 16:9) → ImageManip stretches to 512x384 (4:3) →
+        // NN downsamples to 128x96. Calling calibrationToCameraInfo directly
+        // at (128, 96) would give intrinsics that assume an isotropic scaling
+        // from the sensor — wrong, because the preview→NN-input step is an
+        // anisotropic stretch. Compute the preview-resolution intrinsics from
+        // DepthAI's calibration handler, then scale fx/cx by 128/preview_width
+        // and fy/cy by 96/preview_height to reflect the squish. Distortion
+        // coefficients are left unchanged: they're a small per-pixel correction
+        // in normalised image coordinates, and re-deriving them through a non-
+        // affine resize is non-trivial; the dominant aspect-ratio error in
+        // cell→pixel projection is what we're correcting here.
+        auto preview_camera_info = segmentation_converter_->calibrationToCameraInfo(
+          calibration_handler, dai::CameraBoardSocket::CAM_A,
+          params.preview_width, params.preview_height);
+        constexpr int kSegWidth = 128;
+        constexpr int kSegHeight = 96;
+        const double scale_x = static_cast<double>(kSegWidth) / params.preview_width;
+        const double scale_y = static_cast<double>(kSegHeight) / params.preview_height;
+        segmentation_camera_info_ = preview_camera_info;
+        segmentation_camera_info_.width = kSegWidth;
+        segmentation_camera_info_.height = kSegHeight;
+        // K (3x3 intrinsic matrix, row-major): scale fx, cx by x; fy, cy by y.
+        segmentation_camera_info_.k[0] *= scale_x;  // fx
+        segmentation_camera_info_.k[2] *= scale_x;  // cx
+        segmentation_camera_info_.k[4] *= scale_y;  // fy
+        segmentation_camera_info_.k[5] *= scale_y;  // cy
+        // P (3x4 projection matrix): same scaling on the K-equivalent entries.
+        // Tx (p[3]) and Ty (p[7]) are 0 for a monocular setup; scaling is a
+        // no-op there but kept for correctness if a stereo bridge ever fills
+        // them in.
+        segmentation_camera_info_.p[0] *= scale_x;
+        segmentation_camera_info_.p[2] *= scale_x;
+        segmentation_camera_info_.p[3] *= scale_x;
+        segmentation_camera_info_.p[5] *= scale_y;
+        segmentation_camera_info_.p[6] *= scale_y;
+        segmentation_camera_info_.p[7] *= scale_y;
 
         segmentation_publisher_ = std::make_shared<dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ADatatype> >(
           segmentation_queue_,
@@ -90,6 +127,15 @@ public:
 
         auto image_manip = pipeline->create<dai::node::ImageManip>();
         image_manip->initialConfig.setFrameType(dai::ImgFrame::Type::BGR888p);
+        // EXPLICIT stretch: resize the preview into the NN input shape without
+        // preserving aspect ratio. DepthAI's setResize default is to keep the
+        // aspect ratio (which center-crops or pads), which would silently drop
+        // the side portions of a 16:9 preview when fed to a 4:3 NN. Forcing
+        // keep_aspect_ratio=false stretches the whole preview into 512x384 so
+        // the segmentation covers the full camera FOV — at the cost of
+        // anisotropic pixel scaling, which is corrected in the camera_info
+        // built below.
+        image_manip->initialConfig.setKeepAspectRatio(false);
         image_manip->initialConfig.setResize(512, 384);
 
         // Link camera preview to image manip. Camera FPS is already set by base class.

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cmath>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -598,6 +599,49 @@ TEST(ProjectObservationsInverse, ContactCellHitsBodyCellsSkipped)
       EXPECT_LT(o.log_odds, 0.0) << "water (R=0) must yield negative graded evidence";
     }
   }
+}
+
+// #26 fix: a single waterline contact in a sea of water. The forward backstop
+// emits the contact's obstacle evidence at its footprint, but the inverse cell
+// loop emits WATER for the cell whose centre samples adjacent water. With the
+// downstream additive accumulate this washes the contact out; max-pooling each
+// cell to its (obstacle-preferring) max keeps the cell obstacle. This is the
+// buoy-not-marking case.
+TEST(ProjectObservationsInverse, MaxPoolKeepsContactOverColocatedWater)
+{
+  cv::Mat mask(12, 16, CV_8UC3, cv::Scalar(0, 200, 0));  // water everywhere
+  mask.at<cv::Vec3b>(6, 8) = cv::Vec3b(200, 0, 0);       // one contact px (water below)
+
+  const auto pooled = project_observations_inverse(
+    mask, make_small_nadir_camera(), kNadirOrigin, nadir_rotation(),
+    /*max_range=*/100.0, /*cx=*/0.0, /*cy=*/0.0, /*res=*/0.2, /*half_extent=*/1.5,
+    /*plane_z=*/0.0, /*min_grazing=*/0.0, /*obstacle_prob_min=*/0.5,
+    /*max_evidence_step=*/0.85, /*max_pool_bins=*/true);
+  const auto raw = project_observations_inverse(
+    mask, make_small_nadir_camera(), kNadirOrigin, nadir_rotation(),
+    /*max_range=*/100.0, /*cx=*/0.0, /*cy=*/0.0, /*res=*/0.2, /*half_extent=*/1.5,
+    /*plane_z=*/0.0, /*min_grazing=*/0.0, /*obstacle_prob_min=*/0.5,
+    /*max_evidence_step=*/0.85, /*max_pool_bins=*/false);
+
+  // Collapse invariant: at most one observation per accumulator cell.
+  std::set<std::pair<long, long>> cells;
+  for (const auto & o : pooled) {
+    const auto key = std::make_pair(std::lround(o.x / 0.2), std::lround(o.y / 0.2));
+    EXPECT_TRUE(cells.insert(key).second) << "max-pool must emit one observation per cell";
+  }
+
+  // The contact marks at least one cell, and every obstacle obs is positive.
+  auto [obstacle, free] = count_obs(pooled);
+  EXPECT_GE(obstacle, 1) << "the waterline contact must mark at least one cell";
+  EXPECT_GT(free, 0) << "surrounding water must still be cleared";
+  for (const auto & o : pooled) {
+    if (o.obstacle) {
+      EXPECT_GT(o.log_odds, 0.0);
+    }
+  }
+
+  // Un-pooled emits more observations (the per-cell duplicates the pool collapses).
+  EXPECT_GE(raw.size(), pooled.size());
 }
 
 // Cells beyond max_range (even when in-image) are dropped by the Euclidean


### PR DESCRIPTION
Imports the exploratory on-water changes from BizzyBoat deployment rolker/unh_echoboats_project11#197 as the **starting baseline** for the costmap investigation in #26.

Three commits (close-buoy contact backstop, per-source `image_mask_rects`, anisotropic segmentation `camera_info` + explicit stretch). These were **exploratory ideas tried on the water, not validated fixes** — see the gabby field log in #197 for the debugging narrative.

**Draft**: a baseline to build on, not a finished fix. The marking gap is investigated interactively via `sea_surface_tuner` (see #26). Unit tests + validation follow once an approach is settled — premature on the exploratory baseline.

Part of #26 (does not close it — the investigation continues there).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
