### PR TITLE
Segmentation output stamped with now() instead of frame capture time (~123 ms late) → stale pose, buoy misses costmap

### DIFF
--- a/.agent/work-plans/issue-28/plan.md
+++ b/.agent/work-plans/issue-28/plan.md
@@ -30,7 +30,23 @@ publishers use. The established conversion pattern is `depthai_marine`'s
   `localCameraInfo.header.stamp = currMsg.header.stamp`). **So fixing the Image
   stamp auto-propagates to `segmentation/camera_info`.** The `segmentation/compressed`
   sibling is an image_transport republish of the same Image → inherits the stamp too.
-  Net: the fix is the **one** Image stamp.
+- The depthai_bridge `ImageConverter` honors `setUpdateRosBaseTimeOnToRosMsg(true)`
+  in **both** consumer paths — `toRosMsgRawPtr` (used by `ImagePublisher`'s
+  `toRosMsg`) and `toRosFFMPEGPacket` (used by `FFMPEGPublisher`) each call
+  `updateRosBaseTime()` when the flag is set (verified in upstream
+  `depthai_bridge/src/ImageConverter.cpp`). So the camera-publisher frozen-anchor
+  fix is a clean one-liner per publisher.
+
+**Scope decision (Roland, 2026-06-02): bundle the frozen-anchor fix.** The camera
+publishers (`ImagePublisher`/`FFMPEGPublisher` in `depthai_marine`) freeze their
+ROS↔steady anchor at converter construction and never re-sync — the same class of
+defect, latent in this run. Leaving wrong behavior wrong isn't justified by "blast
+radius": correcting it is a bug fix, not a risky behavior change. So this PR also
+flips both converters to per-message re-anchor. With the segmentation node *also*
+re-anchoring (below), all three stamping paths use one consistent strategy, so the
+`sea_surface_tuner` δ-sweep that correlates seg-vs-ffmpeg stays ≈0 even under clock
+slew (the earlier seg-vs-camera divergence concern is thereby removed, not just
+deferred).
 
 ## Approach
 
@@ -48,13 +64,23 @@ publishers use. The established conversion pattern is `depthai_marine`'s
 3. **Replace line 162** with
    `image_message.header.stamp = deviceFrameStamp(ros_base_time_, steady_base_time_, total_ns_change_, in_det->getTimestamp());`
 4. **Enable the per-message re-anchor** (`updateBaseTime`, inside the helper) so the
-   stamp tracks the live ROS clock that `/tf` uses — see Open Question 1 for the
-   anchoring-strategy trade-off and the deferred camera-publisher frozen-anchor.
-5. **Add `test/test_segmentation_stamp.cpp`** (gtest): feed synthetic anchors + a
+   segmentation stamp tracks the live ROS clock that `/tf` uses (robust to clock
+   slew). This is the chosen anchoring strategy (resolves former Open Question 1).
+5. **Fix the camera-publisher frozen anchor (bundled).** Add
+   `image_converter_->setUpdateRosBaseTimeOnToRosMsg(true);` in
+   `depthai_marine/src/image_publisher.cpp` (after the converter is built, line 14)
+   and `converter_->setUpdateRosBaseTimeOnToRosMsg(true);` in
+   `depthai_marine/src/ffmpeg_publisher.cpp` (after line 25). One line each; both
+   converter paths honor the flag (verified against the jazzy branch source — see
+   Context). This is its **own commit** (`depthai_marine`), separate from the
+   segmentation-package commit, to keep each logical change atomic within the one PR.
+6. **Add `test/test_segmentation_stamp.cpp`** (gtest): feed synthetic anchors + a
    device timestamp offset by a known Δ, assert the returned stamp equals the
    expected capture-derived ROS time and is **not** ≈ `now()`. Register in
    `CMakeLists.txt` (`ament_add_gtest`), link `depthai_bridge` for `getFrameTime`.
-6. **Manual/offline verification** (cannot run on-device in CI): re-run
+   (The camera-publisher one-liners are flag flips on the upstream converter — not
+   meaningfully unit-testable without hardware; covered by the offline bag re-run.)
+7. **Manual/offline verification** (cannot run on-device in CI): re-run
    `sea_surface_tuner` on `bag_2026-05-29T15.56.42_ffmpeg_seg` — port horizon
    overlay should sit on the true horizon through the pier-departure turn, the
    ~t6 s yellow buoy should mark, and the δ-sweep best alignment should move from
@@ -68,6 +94,8 @@ publishers use. The established conversion pattern is `depthai_marine`'s
 | `sea_surface_segmentation/src/segmentation_stamp.hpp` (new) | Pure helper wrapping `dai::ros::updateBaseTime` + `getFrameTime` |
 | `sea_surface_segmentation/test/test_segmentation_stamp.cpp` (new) | gtest: stamp derives from device tstamp, not `now()` |
 | `sea_surface_segmentation/CMakeLists.txt` | Register the new gtest |
+| `depthai_marine/src/image_publisher.cpp` | `image_converter_->setUpdateRosBaseTimeOnToRosMsg(true)` — fix frozen anchor |
+| `depthai_marine/src/ffmpeg_publisher.cpp` | `converter_->setUpdateRosBaseTimeOnToRosMsg(true)` — fix frozen anchor |
 
 ## Principles Self-Check
 
@@ -92,26 +120,21 @@ publishers use. The established conversion pattern is `depthai_marine`'s
 | Stamp now ~123 ms earlier | TF lookups happen at an older time | Within tf buffer history and well within consumers' tolerances (costmap `transform_tolerance` 0.2 s, Collision Monitor `source_timeout` 1.0 s) — no lookup failures |
 | `recv − stamp` latency metric grows ~123 ms | Any diagnostic that alarms on stamp age | Expected/correct (stamp is now the true capture time); no code asserts on this |
 | camera_info / compressed siblings | Must carry corrected stamp | Auto-propagate (BridgePublisher:245 + image_transport) — verify in the tuner re-run |
+| Camera-publisher re-anchor (`depthai_marine`) | Affects **all** consumers of the raw / ffmpeg-h265 / camera_info topics across every platform using `depthai_marine` (all OAKs, not just segmentation) | Correctness fix (stamps track live clock); in normal NTP-locked operation (no slew) stamps are unchanged. Verify raw/h265 stamps still look correct in the bag re-run |
 
 ## Open Questions
 
-- **Anchoring strategy (recommend: re-anchor).** Per-message `updateBaseTime`
-  re-syncs the anchor to the live ROS clock each frame, so the projection-critical
-  segmentation stamp tracks the same clock `/tf` uses (robust to NTP slew). The
-  alternative — freeze the anchor at construction to exactly match the camera
-  publishers — keeps seg-vs-camera-raw stamps identical but reintroduces a slow
-  stale-pose drift under clock slew (the camera raw isn't projected, so this matters
-  less). The run showed no slew (camera/tf flat to 0.3 ms over 1021 s), so both fix
-  the 123 ms bug; re-anchor is the safer default. **Confirm.**
-- **Camera-publisher frozen-anchor follow-up.** The issue flags a *separate* latent
-  bug: `ImagePublisher`/`FFMPEGPublisher` converters freeze their anchor at
-  construction and never re-sync. It did not fire in this run. Out of scope here
-  (touches `depthai_marine`, expands the diff near the freeze) — **surface as a new
-  issue** rather than silently bundling or dropping it. Agreed to defer?
+- ~~**Anchoring strategy?**~~ **Resolved (Roland, 2026-06-02):** per-message
+  re-anchor (`updateBaseTime`) for all three stamping paths.
+- ~~**Camera-publisher frozen-anchor: defer?**~~ **Resolved (Roland, 2026-06-02):
+  bundle it.** Fixing wrong behavior is a bug fix, not a risky change — both
+  `depthai_marine` converters get the re-anchor flag in this PR (own commit).
 - **Freeze timing.** June 4 dev freeze; small high-value change for the June 15
   survey. Confirm this lands before the freeze.
 
 ## Estimated Scope
 
-Single PR (one stamp fix + pure helper + one gtest). On-device / tuner verification
-is a manual follow-up, not a CI gate.
+Single PR, **two atomic commits**: (1) segmentation stamp fix + pure helper + gtest
+(`sea_surface_segmentation`); (2) camera-publisher re-anchor flag
+(`depthai_marine`). On-device / tuner verification is a manual follow-up, not a CI
+gate.

--- a/.agent/work-plans/issue-28/plan.md
+++ b/.agent/work-plans/issue-28/plan.md
@@ -55,12 +55,13 @@ deferred).
    `int64_t total_ns_change_ = 0`, captured at construction
    (`ros_base_time_ = node->get_clock()->now(); steady_base_time_ = std::chrono::steady_clock::now();`),
    mirroring `measure_timing.cpp:130-131`.
-2. **Extract a pure stamping helper** for testability — `src/segmentation_stamp.hpp`
+2. **Extract a hardware-independent stamping helper** — `src/segmentation_stamp.hpp`
    (header-only, sibling of `frame_id_resolver.hpp`):
-   `rclcpp::Time deviceFrameStamp(rclcpp::Time & ros_base, steady_tp & steady_base, int64_t & total_ns_change, steady_tp device_tstamp)`
+   `rclcpp::Time deviceFrameStamp(rclcpp::Time & ros_base, const steady_tp & steady_base, int64_t & total_ns_change, const steady_tp & device_tstamp)`
    that re-anchors (`dai::ros::updateBaseTime`) then returns `dai::ros::getFrameTime(...)`.
-   Taking the already-extracted `time_point` (not the `NNData`) keeps it free of any
-   device dependency so it unit-tests without hardware.
+   Not pure (the re-anchor reads `now()`), but taking the already-extracted
+   `time_point` (not the `NNData`) keeps it free of any device dependency so it
+   unit-tests without hardware.
 3. **Replace line 162** with
    `image_message.header.stamp = deviceFrameStamp(ros_base_time_, steady_base_time_, total_ns_change_, in_det->getTimestamp());`
 4. **Enable the per-message re-anchor** (`updateBaseTime`, inside the helper) so the
@@ -79,19 +80,41 @@ deferred).
    expected capture-derived ROS time and is **not** ≈ `now()`. Register in
    `CMakeLists.txt` (`ament_add_gtest`), link `depthai_bridge` for `getFrameTime`.
    (The camera-publisher one-liners are flag flips on the upstream converter — not
-   meaningfully unit-testable without hardware; covered by the offline bag re-run.)
-7. **Manual/offline verification** (cannot run on-device in CI): re-run
-   `sea_surface_tuner` on `bag_2026-05-29T15.56.42_ffmpeg_seg` — port horizon
-   overlay should sit on the true horizon through the pier-departure turn, the
-   ~t6 s yellow buoy should mark, and the δ-sweep best alignment should move from
-   δ≈−123 ms to δ≈0.
+   meaningfully unit-testable without hardware.)
+
+## Verification — what proves what (needs fresh data)
+
+The existing bag **cannot** verify the deployed fix: the bug *discards* the device
+timestamp inside the node, so the bag never recorded the `dai::NNData` capture
+times; its segmentation `Image` stamps are baked wrong (δ≈−123 ms forever), and the
+segmentation node is on-device (reads the OAK NN queue) so it can't be replayed from
+a bag. Three tiers, in order of what they establish:
+
+1. **gtest (`test_segmentation_stamp`) — logic only.** Exercise `deviceFrameStamp`
+   with a synthetic device timestamp ~200 ms in the past; assert the returned stamp
+   is ~200 ms behind wall-clock `now()` (i.e. capture-relative, **not** `now()`).
+   Guards the helper contract; says nothing about real poses. CI-runnable.
+2. **Bench/dockside OAK run — stamp correctness (pre-freeze gate).** Power the OAK,
+   run the fixed node pointed at *anything* (no water/buoy needed), record the
+   `*_ffmpeg_seg` streams, and check **`seg_stamp − ff_stamp ≈ 0`** per frame (was a
+   tight 123.5 ms). Same source frame, same device clock ⇒ equality is the definitive
+   proof the live stamp fix works. *This is the "test it on the boat soon" gate.*
+3. **On-water buoy scene — the actual goal (deployment).** With a fresh fixed-code
+   recording on the water: port horizon overlay sits on the true horizon through the
+   turn, the close buoy marks in the regenerated costmap, and the `sea_surface_tuner`
+   δ-sweep best-aligns at δ≈0 (not −123 ms). Belongs on deployment
+   **unh_echoboats_project11#205**, not a CI gate.
+
+The old bag's only role: re-running the tuner on it with a +123.5 ms manual
+correction re-confirms the *premise* (corrected pose → horizon aligns, buoy marks) —
+that's the issue's existing evidence, not verification of the deployed code.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
 | `sea_surface_segmentation/src/sea_surface_segmentation.cpp` | Add `ros_base_time_`/`steady_base_time_`/`total_ns_change_` members + init; replace `now()` stamp at line 162 with `deviceFrameStamp(...)` |
-| `sea_surface_segmentation/src/segmentation_stamp.hpp` (new) | Pure helper wrapping `dai::ros::updateBaseTime` + `getFrameTime` |
+| `sea_surface_segmentation/src/segmentation_stamp.hpp` (new) | Stamping helper wrapping `dai::ros::updateBaseTime` + `getFrameTime` |
 | `sea_surface_segmentation/test/test_segmentation_stamp.cpp` (new) | gtest: stamp derives from device tstamp, not `now()` |
 | `sea_surface_segmentation/CMakeLists.txt` | Register the new gtest |
 | `depthai_marine/src/image_publisher.cpp` | `image_converter_->setUpdateRosBaseTimeOnToRosMsg(true)` — fix frozen anchor |

--- a/.agent/work-plans/issue-28/plan.md
+++ b/.agent/work-plans/issue-28/plan.md
@@ -1,0 +1,117 @@
+# Plan: Segmentation output stamped with now() instead of frame capture time
+
+## Issue
+
+https://github.com/rolker/unh_marine_perception/issues/28
+
+## Context
+
+`SegmentorCamera::segmentationCallback` builds its `Image` manually and stamps it
+with wall-clock `now()` (`sea_surface_segmentation.cpp:162`), discarding the
+source frame's device capture time. Measured offset: **+123.5 ms, constant**
+(fixed pipeline latency, not jitter). Every consumer that does a TF lookup at that
+stamp — `SeaSurfaceLayer`, `segments_to_pointcloud`, offline `sea_surface_tuner` —
+resolves the camera pose 123.5 ms stale, which on a turning vehicle rotates the
+back-projection enough that a clearly-segmented close buoy walks several costmap
+cells/frame and never accumulates. This is the pose-timing half of the #26/#27
+small-buoy marking gap; not fixable in the projection algorithm.
+
+The callback already holds `in_det` (`dai::NNData`), which carries the device
+capture timestamp via `in_det->getTimestamp()` — the same source the camera
+publishers use. The established conversion pattern is `depthai_marine`'s
+`measure_timing.cpp:256-257`:
+`msg.header.stamp = dai::ros::getFrameTime(ros_base_time_, steady_base_time_, det->getTimestamp());`
+
+**Verified during planning:**
+- `CameraBase` does **not** hold `ros_base_time_`/`steady_base_time_` (they live
+  inside the publishers' `ImageConverter`s). So `SegmentorCamera` must add its own.
+- `BridgePublisher::publishHelper` copies the image stamp onto camera_info
+  (`/opt/ros/jazzy/include/depthai_bridge/BridgePublisher.hpp:245`:
+  `localCameraInfo.header.stamp = currMsg.header.stamp`). **So fixing the Image
+  stamp auto-propagates to `segmentation/camera_info`.** The `segmentation/compressed`
+  sibling is an image_transport republish of the same Image → inherits the stamp too.
+  Net: the fix is the **one** Image stamp.
+
+## Approach
+
+1. **Add time anchors to `SegmentorCamera`** — members `rclcpp::Time ros_base_time_`,
+   `std::chrono::time_point<std::chrono::steady_clock> steady_base_time_`, and
+   `int64_t total_ns_change_ = 0`, captured at construction
+   (`ros_base_time_ = node->get_clock()->now(); steady_base_time_ = std::chrono::steady_clock::now();`),
+   mirroring `measure_timing.cpp:130-131`.
+2. **Extract a pure stamping helper** for testability — `src/segmentation_stamp.hpp`
+   (header-only, sibling of `frame_id_resolver.hpp`):
+   `rclcpp::Time deviceFrameStamp(rclcpp::Time & ros_base, steady_tp & steady_base, int64_t & total_ns_change, steady_tp device_tstamp)`
+   that re-anchors (`dai::ros::updateBaseTime`) then returns `dai::ros::getFrameTime(...)`.
+   Taking the already-extracted `time_point` (not the `NNData`) keeps it free of any
+   device dependency so it unit-tests without hardware.
+3. **Replace line 162** with
+   `image_message.header.stamp = deviceFrameStamp(ros_base_time_, steady_base_time_, total_ns_change_, in_det->getTimestamp());`
+4. **Enable the per-message re-anchor** (`updateBaseTime`, inside the helper) so the
+   stamp tracks the live ROS clock that `/tf` uses — see Open Question 1 for the
+   anchoring-strategy trade-off and the deferred camera-publisher frozen-anchor.
+5. **Add `test/test_segmentation_stamp.cpp`** (gtest): feed synthetic anchors + a
+   device timestamp offset by a known Δ, assert the returned stamp equals the
+   expected capture-derived ROS time and is **not** ≈ `now()`. Register in
+   `CMakeLists.txt` (`ament_add_gtest`), link `depthai_bridge` for `getFrameTime`.
+6. **Manual/offline verification** (cannot run on-device in CI): re-run
+   `sea_surface_tuner` on `bag_2026-05-29T15.56.42_ffmpeg_seg` — port horizon
+   overlay should sit on the true horizon through the pier-departure turn, the
+   ~t6 s yellow buoy should mark, and the δ-sweep best alignment should move from
+   δ≈−123 ms to δ≈0.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `sea_surface_segmentation/src/sea_surface_segmentation.cpp` | Add `ros_base_time_`/`steady_base_time_`/`total_ns_change_` members + init; replace `now()` stamp at line 162 with `deviceFrameStamp(...)` |
+| `sea_surface_segmentation/src/segmentation_stamp.hpp` (new) | Pure helper wrapping `dai::ros::updateBaseTime` + `getFrameTime` |
+| `sea_surface_segmentation/test/test_segmentation_stamp.cpp` (new) | gtest: stamp derives from device tstamp, not `now()` |
+| `sea_surface_segmentation/CMakeLists.txt` | Register the new gtest |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Quality Standard — fix completely + test | Fixes the root cause (not the projection symptom); adds a deterministic CI test; siblings (camera_info/compressed) verified to auto-propagate, so none left stale. |
+| Robustness for open-water autonomy | Correct pose timing is what lets the reflex/costmap actually mark close obstacles — directly safety-relevant for the buoy-miss class. |
+| Verify docs/claims against source | BridgePublisher stamp-copy and CameraBase anchor-absence were verified in source during planning, not assumed. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0008 Follow ROS 2 conventions | Yes | Using the sensor's hardware capture timestamp in `header.stamp` (not host arrival time) is the ROS convention; mirrors the existing `depthai_marine` publishers. |
+| ADR-0002 Worktree isolation | Yes | Work on `feature/issue-28`; this plan is the first commit. |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| Segmentation stamp (publish-time → capture-time) | `SeaSurfaceLayer`, `segments_to_pointcloud`, `sea_surface_tuner` all consume this stamp | No change needed — they *want* capture time; the fix is transparent and corrective |
+| Stamp now ~123 ms earlier | TF lookups happen at an older time | Within tf buffer history and well within consumers' tolerances (costmap `transform_tolerance` 0.2 s, Collision Monitor `source_timeout` 1.0 s) — no lookup failures |
+| `recv − stamp` latency metric grows ~123 ms | Any diagnostic that alarms on stamp age | Expected/correct (stamp is now the true capture time); no code asserts on this |
+| camera_info / compressed siblings | Must carry corrected stamp | Auto-propagate (BridgePublisher:245 + image_transport) — verify in the tuner re-run |
+
+## Open Questions
+
+- **Anchoring strategy (recommend: re-anchor).** Per-message `updateBaseTime`
+  re-syncs the anchor to the live ROS clock each frame, so the projection-critical
+  segmentation stamp tracks the same clock `/tf` uses (robust to NTP slew). The
+  alternative — freeze the anchor at construction to exactly match the camera
+  publishers — keeps seg-vs-camera-raw stamps identical but reintroduces a slow
+  stale-pose drift under clock slew (the camera raw isn't projected, so this matters
+  less). The run showed no slew (camera/tf flat to 0.3 ms over 1021 s), so both fix
+  the 123 ms bug; re-anchor is the safer default. **Confirm.**
+- **Camera-publisher frozen-anchor follow-up.** The issue flags a *separate* latent
+  bug: `ImagePublisher`/`FFMPEGPublisher` converters freeze their anchor at
+  construction and never re-sync. It did not fire in this run. Out of scope here
+  (touches `depthai_marine`, expands the diff near the freeze) — **surface as a new
+  issue** rather than silently bundling or dropping it. Agreed to defer?
+- **Freeze timing.** June 4 dev freeze; small high-value change for the June 15
+  survey. Confirm this lands before the freeze.
+
+## Estimated Scope
+
+Single PR (one stamp fix + pure helper + one gtest). On-device / tuner verification
+is a manual follow-up, not a CI gate.

--- a/.agent/work-plans/issue-28/progress.md
+++ b/.agent/work-plans/issue-28/progress.md
@@ -14,6 +14,6 @@ issue: 28
 **Phases**: single
 
 ### Open questions
-- [ ] Anchoring strategy: per-message re-anchor (recommended, tracks live ROS clock /tf uses) vs frozen-at-construction (matches camera publishers)?
-- [ ] Camera-publisher frozen-anchor (ImagePublisher/FFMPEGPublisher) — defer to a separate new issue?
+- [x] Anchoring strategy — RESOLVED: per-message re-anchor for all three stamping paths.
+- [x] Camera-publisher frozen-anchor — RESOLVED: bundle into this PR (own commit), not a separate issue.
 - [ ] Confirm this lands before the June 4 dev freeze (for June 15 survey).

--- a/.agent/work-plans/issue-28/progress.md
+++ b/.agent/work-plans/issue-28/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 28
+---
+
+# Issue #28 — Segmentation output stamped with now() instead of frame capture time
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-02 11:52 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-28/plan.md` at `aa1e532`
+**PR**: https://github.com/rolker/unh_marine_perception/pull/29 (`[PLAN]` prefix)
+**Phases**: single
+
+### Open questions
+- [ ] Anchoring strategy: per-message re-anchor (recommended, tracks live ROS clock /tf uses) vs frozen-at-construction (matches camera publishers)?
+- [ ] Camera-publisher frozen-anchor (ImagePublisher/FFMPEGPublisher) — defer to a separate new issue?
+- [ ] Confirm this lands before the June 4 dev freeze (for June 15 survey).

--- a/.agent/work-plans/issue-28/progress.md
+++ b/.agent/work-plans/issue-28/progress.md
@@ -34,3 +34,19 @@ issue: 28
 ### Adversarial verification
 - Static: cpplint clean on changed files; uncrustify divergence is pre-existing base-style (local 0.78.1 version-drift false positive), not on added lines.
 - Claude adversarial verified (incl. disassembling libdepthai_bridge.so): stamping algebra yields capture time (steady_base cancels), both converter paths honor setUpdateRosBaseTimeOnToRosMsg, init ordering safe (anchors set before addPublisherCallback), single-threaded per-camera queue (no data race), gtest proves stamp≠now() and isn't flaky.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-02 12:42 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #29 at `08dc205`
+**Sources**: 2 (Copilot R1 @ `08dc205`, Local Review (Pre-Push) @ `08dc205`)
+**Cross-source confirmations**: 0 (Copilot *corrects* the prior review, not confirms)
+**CI**: none reported on the PR
+
+### Findings
+- [ ] (valid, Copilot) test_segmentation_stamp upper bound `EXPECT_LT(lag_s, 0.25)` is flake-prone — CI scheduler stalls / forward clock steps push lag past 250 ms; loosen the ceiling (regression guard is the lower bound, keep it). Prior Local Review wrongly judged it "not flaky" — `sea_surface_segmentation/test/test_segmentation_stamp.cpp:32`
+
+### False positives
+- (none)

--- a/.agent/work-plans/issue-28/progress.md
+++ b/.agent/work-plans/issue-28/progress.md
@@ -17,3 +17,20 @@ issue: 28
 - [x] Anchoring strategy — RESOLVED: per-message re-anchor for all three stamping paths.
 - [x] Camera-publisher frozen-anchor — RESOLVED: bundle into this PR (own commit), not a separate issue.
 - [ ] Confirm this lands before the June 4 dev freeze (for June 15 survey).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-02 12:33 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+**Branch**: feature/issue-28 at `c376154`
+**Mode**: pre-push
+**Depth**: Standard (reason: perception change feeding costmap/reflex; 2 packages)
+**Must-fix**: 0 | **Suggestions**: 1 (addressed)
+
+### Findings
+- [x] (suggestion) segmentationCallback dereferenced a null-able NNData cast (pre-existing) — FIXED, added null guard matching sibling publishers — `sea_surface_segmentation.cpp:164`
+
+### Adversarial verification
+- Static: cpplint clean on changed files; uncrustify divergence is pre-existing base-style (local 0.78.1 version-drift false positive), not on added lines.
+- Claude adversarial verified (incl. disassembling libdepthai_bridge.so): stamping algebra yields capture time (steady_base cancels), both converter paths honor setUpdateRosBaseTimeOnToRosMsg, init ordering safe (anchors set before addPublisherCallback), single-threaded per-camera queue (no data race), gtest proves stamp≠now() and isn't flaky.

--- a/depthai_marine/src/ffmpeg_publisher.cpp
+++ b/depthai_marine/src/ffmpeg_publisher.cpp
@@ -24,6 +24,10 @@ FFMPEGPublisher::FFMPEGPublisher(
   const std::string & resolved_frame_id = frame_id.empty() ? topic_name : frame_id;
   converter_ = std::make_shared<dai::ros::ImageConverter>(resolved_frame_id, true);
   converter_->setFFMPEGEncoding(encoding);
+  // Re-anchor the ROS<->steady base offset on every packet instead of freezing it
+  // at construction (#28) — a frozen anchor drifts from the live ROS clock under
+  // system-clock slew. toRosFFMPEGPacket honors this flag.
+  converter_->setUpdateRosBaseTimeOnToRosMsg(true);
 
   publisher_ = node_->create_publisher<ffmpeg_image_transport_msgs::msg::FFMPEGPacket>(
     topic_name + "/image_raw/ffmpeg",

--- a/depthai_marine/src/image_publisher.cpp
+++ b/depthai_marine/src/image_publisher.cpp
@@ -12,6 +12,11 @@ ImagePublisher::ImagePublisher(std::shared_ptr<rclcpp::Node> node, std::shared_p
   // CameraBase::initialize(), which derives it before getting here.
   const std::string & resolved_frame_id = frame_id.empty() ? topic_name : frame_id;
   image_converter_ = std::make_shared<dai::rosBridge::ImageConverter>(resolved_frame_id, true);
+  // Re-anchor the ROS<->steady base offset on every frame instead of freezing it
+  // at construction (#28). A frozen anchor drifts from the live ROS clock under
+  // any system-clock slew (NTP correction), staling the published stamps; the
+  // converter honors this flag in both toRosMsg and toRosFFMPEGPacket paths.
+  image_converter_->setUpdateRosBaseTimeOnToRosMsg(true);
 
   auto camera_info = image_converter_->calibrationToCameraInfo(calibration_handler, dai::CameraBoardSocket::CAM_A, 1280, 720);
 

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -172,6 +172,21 @@ if(BUILD_TESTING)
     ${CMAKE_CURRENT_SOURCE_DIR}/src
   )
 
+  # segmentation_stamp.hpp is private to the executable (src/); it wraps the
+  # depthai_bridge time helpers (getFrameTime / updateBaseTime) that replaced the
+  # now() stamping in #28. Links depthai_bridge for those helpers and rclcpp for
+  # Time/Clock. No OAK hardware needed — the helper takes an already-extracted
+  # steady_clock time_point, not a dai::NNData.
+  ament_add_gtest(test_segmentation_stamp test/test_segmentation_stamp.cpp)
+  target_include_directories(test_segmentation_stamp PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+  target_link_libraries(test_segmentation_stamp
+    depthai::core
+    depthai_bridge::depthai_bridge
+    rclcpp::rclcpp
+  )
+
   # segments_apply.hpp is an exported core header (include/, on the path via the
   # global include_directories above). Links nav2_costmap_2d_core for Costmap2D.
   ament_add_gtest(test_segments_apply test/test_segments_apply.cpp)

--- a/sea_surface_segmentation/src/sea_surface_segmentation.cpp
+++ b/sea_surface_segmentation/src/sea_surface_segmentation.cpp
@@ -162,6 +162,12 @@ private:
   void segmentationCallback(std::shared_ptr<dai::ADatatype> data, std::deque<sensor_msgs::msg::Image>& outImageMsgs)
   {
     auto in_det = std::dynamic_pointer_cast<dai::NNData>(data);
+    if (!in_det) {
+      // The neural_network queue should only ever carry NNData, but guard the
+      // cast rather than dereference null and crash the node mid-survey — the
+      // sibling depthai_marine publishers null-check their analogous casts too.
+      return;
+    }
     auto layer_data = in_det->getLayerFp16("prediction");
 
     sensor_msgs::msg::Image image_message;

--- a/sea_surface_segmentation/src/sea_surface_segmentation.cpp
+++ b/sea_surface_segmentation/src/sea_surface_segmentation.cpp
@@ -19,6 +19,7 @@
 #include "depthai_marine/image_publisher.hpp"
 
 #include "frame_id_resolver.hpp"
+#include "segmentation_stamp.hpp"
 
 class SegmentorCamera : public depthai_marine::CameraBase
 {
@@ -44,6 +45,13 @@ public:
     // and H.265 packets fell back to the bare `name` (e.g. `oak_forward`),
     // breaking TF lookups for any consumer of those topics.
     initialize(id, name, frame_id_);
+
+    // Capture the ROS<->steady base offset for stamping segmentation frames from
+    // their device capture time (#28). deviceFrameStamp() re-anchors ros_base_time_
+    // on every frame, so the exact capture instant here is immaterial — but the
+    // members must exist before the first segmentation callback fires.
+    ros_base_time_ = node->get_clock()->now();
+    steady_base_time_ = std::chrono::steady_clock::now();
 
     if (enable_nn_) {
         segmentation_queue_ = device_->getOutputQueue("neural_network", 5, false);
@@ -159,7 +167,14 @@ private:
     sensor_msgs::msg::Image image_message;
     image_message.header.frame_id = frame_id_;
 
-    image_message.header.stamp = node_->get_clock()->now(); 
+    // Stamp from the source frame's device capture time, NOT now() (#28). now()
+    // discarded the ~123.5 ms fixed pipeline latency, so every downstream TF
+    // lookup (SeaSurfaceLayer, segments_to_pointcloud, sea_surface_tuner)
+    // resolved a stale camera pose and close buoys never marked. BridgePublisher
+    // copies this stamp onto the camera_info sibling, and image_transport onto
+    // the compressed sibling, so this one stamp corrects the whole group.
+    image_message.header.stamp = sea_surface_segmentation::deviceFrameStamp(
+      ros_base_time_, steady_base_time_, total_ns_change_, in_det->getTimestamp());
 
     image_message.height = 96;
     image_message.width = 128;
@@ -183,6 +198,11 @@ private:
   std::string name_;
   std::string frame_id_;
   bool enable_nn_;
+  // ROS<->steady base offset for converting NNData device capture timestamps to
+  // ROS time (#28). Re-anchored per frame by deviceFrameStamp().
+  rclcpp::Time ros_base_time_;
+  std::chrono::time_point<std::chrono::steady_clock> steady_base_time_;
+  int64_t total_ns_change_ = 0;
   std::shared_ptr<dai::DataOutputQueue> segmentation_queue_;
   std::shared_ptr<dai::rosBridge::ImageConverter> segmentation_converter_;
   std::shared_ptr<dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ADatatype> > segmentation_publisher_;

--- a/sea_surface_segmentation/src/segmentation_stamp.hpp
+++ b/sea_surface_segmentation/src/segmentation_stamp.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+// Private implementation header for the sea_surface_segmentation node.
+// Lives in src/ rather than include/ because the helper has no downstream
+// consumers — it's exercised by `src/sea_surface_segmentation.cpp` and by
+// `test/test_segmentation_stamp.cpp`, nothing else.
+
+#include <chrono>
+#include <cstdint>
+
+#include "rclcpp/time.hpp"
+
+#include "depthai_bridge/depthaiUtility.hpp"
+
+namespace sea_surface_segmentation
+{
+
+using SteadyTimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+
+// Convert a DepthAI device capture timestamp (NNData::getTimestamp(), in the
+// steady-clock domain) to a ROS time, mirroring how the depthai_marine camera
+// publishers stamp their frames. This is what replaced the old, wrong
+// `header.stamp = now()` (issue #28): now() discarded the ~123.5 ms of fixed
+// pipeline latency, so every downstream TF lookup resolved a stale pose.
+//
+// The base offset is re-anchored to the live ROS clock on *every* call
+// (`updateBaseTime`), so the result tracks the same clock `/tf` is stamped on
+// and cannot accumulate the frozen-anchor drift that a once-at-construction
+// anchor would (the latent issue the camera publishers also carried). After the
+// re-anchor, `getFrameTime` returns `now_ros + (device_timestamp - now_steady)`,
+// i.e. the true capture time expressed against the current ROS clock.
+//
+// `ros_base_time` / `total_ns_change` are mutated by the re-anchor and must be
+// the caller's persistent members (one per stamping path). `steady_base_time` is
+// copied by `updateBaseTime`, so its stored value is immaterial after the first
+// call — kept as a parameter to match the depthai_bridge convention.
+//
+// Takes the already-extracted `time_point` rather than the `dai::NNData` so the
+// helper has no device dependency and unit-tests without OAK hardware.
+inline rclcpp::Time deviceFrameStamp(
+  rclcpp::Time & ros_base_time,
+  const SteadyTimePoint & steady_base_time,
+  int64_t & total_ns_change,
+  const SteadyTimePoint & device_timestamp)
+{
+  dai::ros::updateBaseTime(steady_base_time, ros_base_time, total_ns_change);
+  return dai::ros::getFrameTime(ros_base_time, steady_base_time, device_timestamp);
+}
+
+}  // namespace sea_surface_segmentation

--- a/sea_surface_segmentation/test/test_segmentation_stamp.cpp
+++ b/sea_surface_segmentation/test/test_segmentation_stamp.cpp
@@ -28,8 +28,13 @@ TEST(SegmentationStamp, DerivesFromDeviceTimestampNotNow)
     deviceFrameStamp(ros_base, steady_base, total_ns_change, device_ts);
 
   const double lag_s = (clock.now() - stamp).seconds();
-  EXPECT_GT(lag_s, 0.15) << "stamp ~= now() — device timestamp was ignored (the #28 bug)";
-  EXPECT_LT(lag_s, 0.25) << "stamp not ~200 ms in the past as the capture lag implies";
+  // Bounds are deliberately wide: the regression this guards (a revert to now())
+  // collapses the lag to ~0, which the lower bound catches with huge margin. The
+  // upper bound is only a gross sign/scale sanity ceiling — scheduler stalls and
+  // forward clock steps push the lag UP, so a tight ceiling would flake on CI
+  // without adding regression-catching power.
+  EXPECT_GT(lag_s, 0.1) << "stamp ~= now() — device timestamp was ignored (the #28 bug)";
+  EXPECT_LT(lag_s, 1.0) << "stamp implausibly far in the past — conversion sign/scale error";
 }
 
 // The device timestamp must actually drive the result: a later capture (smaller

--- a/sea_surface_segmentation/test/test_segmentation_stamp.cpp
+++ b/sea_surface_segmentation/test/test_segmentation_stamp.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "segmentation_stamp.hpp"
+
+using sea_surface_segmentation::deviceFrameStamp;
+using sea_surface_segmentation::SteadyTimePoint;
+
+// Regression guard for issue #28: the segmentation stamp must derive from the
+// device capture timestamp, NOT wall-clock now(). A frame captured ~200 ms ago
+// must yield a stamp ~200 ms in the past relative to now(); a regression to
+// now() would collapse that lag to ~0.
+TEST(SegmentationStamp, DerivesFromDeviceTimestampNotNow)
+{
+  rclcpp::Clock clock;  // RCL_SYSTEM_TIME — the same clock updateBaseTime reads
+  rclcpp::Time ros_base = clock.now();
+  SteadyTimePoint steady_base = std::chrono::steady_clock::now();
+  int64_t total_ns_change = 0;
+
+  constexpr auto kCaptureLag = std::chrono::milliseconds(200);
+  const SteadyTimePoint device_ts = std::chrono::steady_clock::now() - kCaptureLag;
+
+  const rclcpp::Time stamp =
+    deviceFrameStamp(ros_base, steady_base, total_ns_change, device_ts);
+
+  const double lag_s = (clock.now() - stamp).seconds();
+  EXPECT_GT(lag_s, 0.15) << "stamp ~= now() — device timestamp was ignored (the #28 bug)";
+  EXPECT_LT(lag_s, 0.25) << "stamp not ~200 ms in the past as the capture lag implies";
+}
+
+// The device timestamp must actually drive the result: a later capture (smaller
+// lag) yields a later stamp. Guards against the conversion degenerating to a
+// constant.
+TEST(SegmentationStamp, LaterCaptureYieldsLaterStamp)
+{
+  rclcpp::Clock clock;
+  SteadyTimePoint steady_base = std::chrono::steady_clock::now();
+  int64_t change_older = 0;
+  int64_t change_newer = 0;
+
+  const auto t = std::chrono::steady_clock::now();
+  const SteadyTimePoint older = t - std::chrono::milliseconds(300);
+  const SteadyTimePoint newer = t - std::chrono::milliseconds(100);
+
+  rclcpp::Time ros_base_older = clock.now();
+  rclcpp::Time ros_base_newer = clock.now();
+  const rclcpp::Time stamp_older =
+    deviceFrameStamp(ros_base_older, steady_base, change_older, older);
+  const rclcpp::Time stamp_newer =
+    deviceFrameStamp(ros_base_newer, steady_base, change_newer, newer);
+
+  EXPECT_GT(stamp_newer.nanoseconds(), stamp_older.nanoseconds());
+}


### PR DESCRIPTION
Closes #28

# Plan: Segmentation output stamped with now() instead of frame capture time

## Issue

https://github.com/rolker/unh_marine_perception/issues/28

## Context

`SegmentorCamera::segmentationCallback` builds its `Image` manually and stamps it
with wall-clock `now()` (`sea_surface_segmentation.cpp:162`), discarding the
source frame's device capture time. Measured offset: **+123.5 ms, constant**
(fixed pipeline latency, not jitter). Every consumer that does a TF lookup at that
stamp — `SeaSurfaceLayer`, `segments_to_pointcloud`, offline `sea_surface_tuner` —
resolves the camera pose 123.5 ms stale, which on a turning vehicle rotates the
back-projection enough that a clearly-segmented close buoy walks several costmap
cells/frame and never accumulates. This is the pose-timing half of the #26/#27
small-buoy marking gap; not fixable in the projection algorithm.

The callback already holds `in_det` (`dai::NNData`), which carries the device
capture timestamp via `in_det->getTimestamp()` — the same source the camera
publishers use. The established conversion pattern is `depthai_marine`'s
`measure_timing.cpp:256-257`:
`msg.header.stamp = dai::ros::getFrameTime(ros_base_time_, steady_base_time_, det->getTimestamp());`

**Verified during planning:**
- `CameraBase` does **not** hold `ros_base_time_`/`steady_base_time_` (they live
  inside the publishers' `ImageConverter`s). So `SegmentorCamera` must add its own.
- `BridgePublisher::publishHelper` copies the image stamp onto camera_info
  (`/opt/ros/jazzy/include/depthai_bridge/BridgePublisher.hpp:245`:
  `localCameraInfo.header.stamp = currMsg.header.stamp`). **So fixing the Image
  stamp auto-propagates to `segmentation/camera_info`.** The `segmentation/compressed`
  sibling is an image_transport republish of the same Image → inherits the stamp too.
- The depthai_bridge `ImageConverter` honors `setUpdateRosBaseTimeOnToRosMsg(true)`
  in **both** consumer paths — `toRosMsgRawPtr` (used by `ImagePublisher`'s
  `toRosMsg`) and `toRosFFMPEGPacket` (used by `FFMPEGPublisher`) each call
  `updateRosBaseTime()` when the flag is set (verified in upstream
  `depthai_bridge/src/ImageConverter.cpp`). So the camera-publisher frozen-anchor
  fix is a clean one-liner per publisher.

**Scope decision (Roland, 2026-06-02): bundle the frozen-anchor fix.** The camera
publishers (`ImagePublisher`/`FFMPEGPublisher` in `depthai_marine`) freeze their
ROS↔steady anchor at converter construction and never re-sync — the same class of
defect, latent in this run. Leaving wrong behavior wrong isn't justified by "blast
radius": correcting it is a bug fix, not a risky behavior change. So this PR also
flips both converters to per-message re-anchor. With the segmentation node *also*
re-anchoring (below), all three stamping paths use one consistent strategy, so the
`sea_surface_tuner` δ-sweep that correlates seg-vs-ffmpeg stays ≈0 even under clock
slew (the earlier seg-vs-camera divergence concern is thereby removed, not just
deferred).

## Approach

1. **Add time anchors to `SegmentorCamera`** — members `rclcpp::Time ros_base_time_`,
   `std::chrono::time_point<std::chrono::steady_clock> steady_base_time_`, and
   `int64_t total_ns_change_ = 0`, captured at construction
   (`ros_base_time_ = node->get_clock()->now(); steady_base_time_ = std::chrono::steady_clock::now();`),
   mirroring `measure_timing.cpp:130-131`.
2. **Extract a pure stamping helper** for testability — `src/segmentation_stamp.hpp`
   (header-only, sibling of `frame_id_resolver.hpp`):
   `rclcpp::Time deviceFrameStamp(rclcpp::Time & ros_base, steady_tp & steady_base, int64_t & total_ns_change, steady_tp device_tstamp)`
   that re-anchors (`dai::ros::updateBaseTime`) then returns `dai::ros::getFrameTime(...)`.
   Taking the already-extracted `time_point` (not the `NNData`) keeps it free of any
   device dependency so it unit-tests without hardware.
3. **Replace line 162** with
   `image_message.header.stamp = deviceFrameStamp(ros_base_time_, steady_base_time_, total_ns_change_, in_det->getTimestamp());`
4. **Enable the per-message re-anchor** (`updateBaseTime`, inside the helper) so the
   segmentation stamp tracks the live ROS clock that `/tf` uses (robust to clock
   slew). This is the chosen anchoring strategy (resolves former Open Question 1).
5. **Fix the camera-publisher frozen anchor (bundled).** Add
   `image_converter_->setUpdateRosBaseTimeOnToRosMsg(true);` in
   `depthai_marine/src/image_publisher.cpp` (after the converter is built, line 14)
   and `converter_->setUpdateRosBaseTimeOnToRosMsg(true);` in
   `depthai_marine/src/ffmpeg_publisher.cpp` (after line 25). One line each; both
   converter paths honor the flag (verified against the jazzy branch source — see
   Context). This is its **own commit** (`depthai_marine`), separate from the
   segmentation-package commit, to keep each logical change atomic within the one PR.
6. **Add `test/test_segmentation_stamp.cpp`** (gtest): feed synthetic anchors + a
   device timestamp offset by a known Δ, assert the returned stamp equals the
   expected capture-derived ROS time and is **not** ≈ `now()`. Register in
   `CMakeLists.txt` (`ament_add_gtest`), link `depthai_bridge` for `getFrameTime`.
   (The camera-publisher one-liners are flag flips on the upstream converter — not
   meaningfully unit-testable without hardware; covered by the offline bag re-run.)
7. **Manual/offline verification** (cannot run on-device in CI): re-run
   `sea_surface_tuner` on `bag_2026-05-29T15.56.42_ffmpeg_seg` — port horizon
   overlay should sit on the true horizon through the pier-departure turn, the
   ~t6 s yellow buoy should mark, and the δ-sweep best alignment should move from
   δ≈−123 ms to δ≈0.

## Files to Change

| File | Change |
|------|--------|
| `sea_surface_segmentation/src/sea_surface_segmentation.cpp` | Add `ros_base_time_`/`steady_base_time_`/`total_ns_change_` members + init; replace `now()` stamp at line 162 with `deviceFrameStamp(...)` |
| `sea_surface_segmentation/src/segmentation_stamp.hpp` (new) | Pure helper wrapping `dai::ros::updateBaseTime` + `getFrameTime` |
| `sea_surface_segmentation/test/test_segmentation_stamp.cpp` (new) | gtest: stamp derives from device tstamp, not `now()` |
| `sea_surface_segmentation/CMakeLists.txt` | Register the new gtest |
| `depthai_marine/src/image_publisher.cpp` | `image_converter_->setUpdateRosBaseTimeOnToRosMsg(true)` — fix frozen anchor |
| `depthai_marine/src/ffmpeg_publisher.cpp` | `converter_->setUpdateRosBaseTimeOnToRosMsg(true)` — fix frozen anchor |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Quality Standard — fix completely + test | Fixes the root cause (not the projection symptom); adds a deterministic CI test; siblings (camera_info/compressed) verified to auto-propagate, so none left stale. |
| Robustness for open-water autonomy | Correct pose timing is what lets the reflex/costmap actually mark close obstacles — directly safety-relevant for the buoy-miss class. |
| Verify docs/claims against source | BridgePublisher stamp-copy and CameraBase anchor-absence were verified in source during planning, not assumed. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0008 Follow ROS 2 conventions | Yes | Using the sensor's hardware capture timestamp in `header.stamp` (not host arrival time) is the ROS convention; mirrors the existing `depthai_marine` publishers. |
| ADR-0002 Worktree isolation | Yes | Work on `feature/issue-28`; this plan is the first commit. |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| Segmentation stamp (publish-time → capture-time) | `SeaSurfaceLayer`, `segments_to_pointcloud`, `sea_surface_tuner` all consume this stamp | No change needed — they *want* capture time; the fix is transparent and corrective |
| Stamp now ~123 ms earlier | TF lookups happen at an older time | Within tf buffer history and well within consumers' tolerances (costmap `transform_tolerance` 0.2 s, Collision Monitor `source_timeout` 1.0 s) — no lookup failures |
| `recv − stamp` latency metric grows ~123 ms | Any diagnostic that alarms on stamp age | Expected/correct (stamp is now the true capture time); no code asserts on this |
| camera_info / compressed siblings | Must carry corrected stamp | Auto-propagate (BridgePublisher:245 + image_transport) — verify in the tuner re-run |
| Camera-publisher re-anchor (`depthai_marine`) | Affects **all** consumers of the raw / ffmpeg-h265 / camera_info topics across every platform using `depthai_marine` (all OAKs, not just segmentation) | Correctness fix (stamps track live clock); in normal NTP-locked operation (no slew) stamps are unchanged. Verify raw/h265 stamps still look correct in the bag re-run |

## Open Questions

- ~~**Anchoring strategy?**~~ **Resolved (Roland, 2026-06-02):** per-message
  re-anchor (`updateBaseTime`) for all three stamping paths.
- ~~**Camera-publisher frozen-anchor: defer?**~~ **Resolved (Roland, 2026-06-02):
  bundle it.** Fixing wrong behavior is a bug fix, not a risky change — both
  `depthai_marine` converters get the re-anchor flag in this PR (own commit).
- **Freeze timing.** June 4 dev freeze; small high-value change for the June 15
  survey. Confirm this lands before the freeze.

## Estimated Scope

Single PR, **two atomic commits**: (1) segmentation stamp fix + pure helper + gtest
(`sea_surface_segmentation`); (2) camera-publisher re-anchor flag
(`depthai_marine`). On-device / tuner verification is a manual follow-up, not a CI
gate.
