### PR TITLE
Reflex confidence floor: obstacle_prob_min on segments_to_pointcloud

### DIFF
--- a/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
@@ -73,6 +73,7 @@ struct ProjectionStats
   std::size_t projected = 0;                   // points produced
   std::size_t dropped_nonfinite = 0;           // NaN/Inf ray, u, or point
   std::size_t dropped_behind_or_parallel = 0;  // ray parallel to / behind plane
+  std::size_t dropped_low_confidence = 0;      // P(obstacle) below obstacle_prob_min
 };
 
 // True if the rgb8 pixel passes the "obstacle" classification used by
@@ -173,6 +174,16 @@ inline cv::Matx33d rotation_matrix_from_quaternion(
 //                              per-call counts (obstacle pixels seen, points
 //                              produced, rays dropped). The node forwards
 //                              these to `/diagnostics`. Pass nullptr to skip.
+//   - `obstacle_prob_min`    — confidence floor in [0,1). An obstacle pixel is
+//                              projected only if P(obstacle) = R/(R+G+B) >=
+//                              this. Default 0.0 keeps the historical
+//                              "any argmax-obstacle pixel" behavior; raising it
+//                              (e.g. 0.60) rejects low-confidence returns such
+//                              as calm-water reflections, bringing the reflex
+//                              feed to parity with the costmap layer's own
+//                              obstacle_prob_min. Placed last with a default so
+//                              existing (incl. out-of-package) callers compile
+//                              unchanged.
 //
 // Behavior:
 //   - Iterates every pixel of `mask_rgb8`. Obstacle pixels (per
@@ -201,7 +212,8 @@ inline std::vector<ProjectedPoint> project_obstacle_pixels(
   const cv::Vec3d & camera_origin,
   const cv::Matx33d & rotation_cam_to_target,
   double plane_z = 0.0,
-  ProjectionStats * stats = nullptr)
+  ProjectionStats * stats = nullptr,
+  double obstacle_prob_min = 0.0)
 {
   std::vector<ProjectedPoint> points;
 
@@ -213,6 +225,24 @@ inline std::vector<ProjectedPoint> project_obstacle_pixels(
       }
       if (stats) {
         ++stats->obstacle_pixels;
+      }
+
+      // Confidence floor. The mask channels carry the per-class softmax
+      // (R = obstacle, G = water, B = sky), so P(obstacle) = R / (R+G+B).
+      // obstacle_prob_min == 0.0 disables the gate (back-compat); a positive
+      // value drops low-confidence obstacle pixels (e.g. calm-water
+      // reflections measured at ~0.55) before they ever enter the cloud.
+      if (obstacle_prob_min > 0.0) {
+        const double denom = static_cast<double>(pixel_value[0]) +
+          static_cast<double>(pixel_value[1]) + static_cast<double>(pixel_value[2]);
+        const double p_obstacle =
+          denom > 0.0 ? static_cast<double>(pixel_value[0]) / denom : 0.0;
+        if (p_obstacle < obstacle_prob_min) {
+          if (stats) {
+            ++stats->dropped_low_confidence;
+          }
+          continue;
+        }
       }
 
       // Ray direction in the camera optical frame.

--- a/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
+++ b/sea_surface_segmentation/include/sea_surface_segmentation/segments_projection.hpp
@@ -174,9 +174,13 @@ inline cv::Matx33d rotation_matrix_from_quaternion(
 //                              per-call counts (obstacle pixels seen, points
 //                              produced, rays dropped). The node forwards
 //                              these to `/diagnostics`. Pass nullptr to skip.
-//   - `obstacle_prob_min`    — confidence floor in [0,1). An obstacle pixel is
+//   - `obstacle_prob_min`    — confidence floor. An obstacle pixel is
 //                              projected only if P(obstacle) = R/(R+G+B) >=
-//                              this. Default 0.0 keeps the historical
+//                              this (0.0 disables the gate; higher = stricter).
+//                              Because the mask channels are a softmax x255
+//                              (they sum to 255), R/(R+G+B) == R/255, i.e. the
+//                              same P(obstacle) the costmap layer thresholds.
+//                              Default 0.0 keeps the historical
 //                              "any argmax-obstacle pixel" behavior; raising it
 //                              (e.g. 0.60) rejects low-confidence returns such
 //                              as calm-water reflections, bringing the reflex

--- a/sea_surface_segmentation/package.xml
+++ b/sea_surface_segmentation/package.xml
@@ -25,6 +25,7 @@
   <depend>pluginlib</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rosbag2_cpp</depend>

--- a/sea_surface_segmentation/src/segments_to_pointcloud.cpp
+++ b/sea_surface_segmentation/src/segments_to_pointcloud.cpp
@@ -46,14 +46,22 @@ public:
     // Legacy parameter — projection plane is the z=0 plane of this
     // frame. Default "map" preserves pre-refactor behavior. Used as
     // the projection target when `target_frame` is empty.
-    map_frame_ = declare_parameter<std::string>("map_frame", "map");
+    // All declares below are guarded with has_parameter() so a managed
+    // configure -> cleanup -> configure cycle does not re-declare (which throws
+    // ParameterAlreadyDeclaredException, since on_cleanup does not undeclare).
+    // Same intent as the diagnostic_updater guard further down.
+    map_frame_ = has_parameter("map_frame")
+      ? get_parameter("map_frame").as_string()
+      : declare_parameter<std::string>("map_frame", "map");
 
     // Optional override that lets a parallel instance project into a
     // failure-stage-independent frame (e.g. `bizzy/base_link_level`
     // for the nav2_collision_monitor reflex feed). When non-empty,
     // both the TF lookup and the output `header.frame_id` use this
     // frame instead of `map_frame`.
-    target_frame_ = declare_parameter<std::string>("target_frame", "");
+    target_frame_ = has_parameter("target_frame")
+      ? get_parameter("target_frame").as_string()
+      : declare_parameter<std::string>("target_frame", "");
 
     // z-coordinate of the projection plane in whichever frame is
     // used. 0.0 matches the historical map-frame ground-plane
@@ -61,7 +69,9 @@ public:
     // mode too — the hull-floor-vs-waterline offset is treated as
     // part of the Collision Monitor polygon-sizing budget; this
     // param exists for tuning if field data demands it.
-    projection_plane_z_ = declare_parameter<double>("projection_plane_z", 0.0);
+    projection_plane_z_ = has_parameter("projection_plane_z")
+      ? get_parameter("projection_plane_z").as_double()
+      : declare_parameter<double>("projection_plane_z", 0.0);
 
     // Confidence floor for the reflex obstacle feed. Mirrors the costmap
     // SeaSurfaceLayer's obstacle_prob_min: an obstacle pixel is projected only
@@ -74,38 +84,45 @@ public:
     rcl_interfaces::msg::ParameterDescriptor obstacle_prob_min_desc;
     obstacle_prob_min_desc.description =
       "Reflex confidence floor: project an obstacle pixel only if "
-      "P(obstacle)=R/(R+G+B) >= this. 0.0 disables the gate.";
+      "P(obstacle)=R/(R+G+B) >= this. 0.0 disables the gate. Capped below 1.0 "
+      "so a single value cannot blind the reflex feed.";
     obstacle_prob_min_desc.read_only = false;
     {
       rcl_interfaces::msg::FloatingPointRange range;
       range.from_value = 0.0;
-      range.to_value = 1.0;
-      range.step = 0.05;
+      // Capped at 0.95 (not 1.0): on a safety feed, 1.0 would drop every
+      // obstacle pixel except a pure-red one, silently blinding the reflex.
+      range.to_value = 0.95;
+      range.step = 0.0;  // continuous — do not snap to a grid (e.g. 0.62 stays settable)
       obstacle_prob_min_desc.floating_point_range.push_back(range);
     }
-    obstacle_prob_min_ =
+    if (!has_parameter("obstacle_prob_min")) {
       declare_parameter<double>("obstacle_prob_min", 0.0, obstacle_prob_min_desc);
+    }
+    obstacle_prob_min_ = get_parameter("obstacle_prob_min").as_double();
 
     // Keep obstacle_prob_min_ live so rqt_reconfigure / `ros2 param set` (and,
-    // later, the marine_control panel) retune it without a relaunch. Registered
-    // after the declare above, so it only fires for subsequent sets.
-    param_cb_handle_ = add_on_set_parameters_callback(
-      [this](const std::vector<rclcpp::Parameter> & params) {
-        rcl_interfaces::msg::SetParametersResult result;
-        result.successful = true;
-        for (const auto & p : params) {
-          if (p.get_name() == "obstacle_prob_min") {
-            const double v = p.as_double();
-            if (!std::isfinite(v) || v < 0.0 || v > 1.0) {
-              result.successful = false;
-              result.reason = "obstacle_prob_min must be finite and in [0, 1]";
-            } else {
-              obstacle_prob_min_ = v;
+    // later, the marine_control panel) retune it without a relaunch. Guarded so
+    // a configure -> cleanup -> configure cycle registers exactly one callback.
+    if (!param_cb_handle_) {
+      param_cb_handle_ = add_on_set_parameters_callback(
+        [this](const std::vector<rclcpp::Parameter> & params) {
+          rcl_interfaces::msg::SetParametersResult result;
+          result.successful = true;
+          for (const auto & p : params) {
+            if (p.get_name() == "obstacle_prob_min") {
+              const double v = p.as_double();
+              if (!std::isfinite(v) || v < 0.0 || v > 0.95) {
+                result.successful = false;
+                result.reason = "obstacle_prob_min must be finite and in [0, 0.95]";
+              } else {
+                obstacle_prob_min_ = v;
+              }
             }
           }
-        }
-        return result;
-      });
+          return result;
+        });
+    }
 
     tf_buffer_ =
     std::make_unique<tf2_ros::Buffer>(this->get_clock());

--- a/sea_surface_segmentation/src/segments_to_pointcloud.cpp
+++ b/sea_surface_segmentation/src/segments_to_pointcloud.cpp
@@ -12,15 +12,21 @@
 #include "diagnostic_updater/diagnostic_updater.hpp"
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "rcl_interfaces/msg/floating_point_range.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+
 #include "cv_bridge/cv_bridge.hpp"
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "sea_surface_segmentation/segments_projection.hpp"
 
@@ -56,6 +62,50 @@ public:
     // part of the Collision Monitor polygon-sizing budget; this
     // param exists for tuning if field data demands it.
     projection_plane_z_ = declare_parameter<double>("projection_plane_z", 0.0);
+
+    // Confidence floor for the reflex obstacle feed. Mirrors the costmap
+    // SeaSurfaceLayer's obstacle_prob_min: an obstacle pixel is projected only
+    // if P(obstacle) = R/(R+G+B) >= this. Default 0.0 = off (historical
+    // behavior, no change for existing consumers); platforms raise it
+    // (BizzyBoat: 0.60) to reject low-confidence returns such as calm-water
+    // reflections. Declared with a descriptor so it is rqt_reconfigure-tunable
+    // now and bindable by the marine_control remote panel
+    // (unh_marine_autonomy#140 / ADR-0003).
+    rcl_interfaces::msg::ParameterDescriptor obstacle_prob_min_desc;
+    obstacle_prob_min_desc.description =
+      "Reflex confidence floor: project an obstacle pixel only if "
+      "P(obstacle)=R/(R+G+B) >= this. 0.0 disables the gate.";
+    obstacle_prob_min_desc.read_only = false;
+    {
+      rcl_interfaces::msg::FloatingPointRange range;
+      range.from_value = 0.0;
+      range.to_value = 1.0;
+      range.step = 0.05;
+      obstacle_prob_min_desc.floating_point_range.push_back(range);
+    }
+    obstacle_prob_min_ =
+      declare_parameter<double>("obstacle_prob_min", 0.0, obstacle_prob_min_desc);
+
+    // Keep obstacle_prob_min_ live so rqt_reconfigure / `ros2 param set` (and,
+    // later, the marine_control panel) retune it without a relaunch. Registered
+    // after the declare above, so it only fires for subsequent sets.
+    param_cb_handle_ = add_on_set_parameters_callback(
+      [this](const std::vector<rclcpp::Parameter> & params) {
+        rcl_interfaces::msg::SetParametersResult result;
+        result.successful = true;
+        for (const auto & p : params) {
+          if (p.get_name() == "obstacle_prob_min") {
+            const double v = p.as_double();
+            if (!std::isfinite(v) || v < 0.0 || v > 1.0) {
+              result.successful = false;
+              result.reason = "obstacle_prob_min must be finite and in [0, 1]";
+            } else {
+              obstacle_prob_min_ = v;
+            }
+          }
+        }
+        return result;
+      });
 
     tf_buffer_ =
     std::make_unique<tf2_ros::Buffer>(this->get_clock());
@@ -167,8 +217,10 @@ private:
       const auto image = cv_bridge::toCvShare(segments_msg, "rgb8");
       sea_surface_segmentation::ProjectionStats stats;
       const auto points = sea_surface_segmentation::project_obstacle_pixels(
-        image->image, *camera_model_, camera_origin, rotation, projection_plane_z_, &stats);
+        image->image, *camera_model_, camera_origin, rotation, projection_plane_z_, &stats,
+        obstacle_prob_min_);
       nonfinite_dropped_ += stats.dropped_nonfinite;
+      low_confidence_dropped_ += stats.dropped_low_confidence;
 
       pcl::PointCloud<pcl::PointXYZI> cloud;
       cloud.reserve(points.size());
@@ -230,6 +282,8 @@ private:
     stat.add("clouds_published", static_cast<int>(clouds_published_));
     stat.add("tf_lookup_failures", static_cast<int>(tf_failures_));
     stat.add("nonfinite_points_dropped", static_cast<int>(nonfinite_dropped_));
+    stat.add("obstacle_prob_min", obstacle_prob_min_);
+    stat.add("low_confidence_points_dropped", static_cast<int>(low_confidence_dropped_));
 
     if (frames_received_ > 0) {
       stat.add("seconds_since_last_frame", (now() - last_frame_time_).seconds());
@@ -281,6 +335,8 @@ private:
   std::string map_frame_;
   std::string target_frame_;
   double projection_plane_z_{0.0};
+  double obstacle_prob_min_{0.0};
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_handle_;
 
   std::unique_ptr<diagnostic_updater::Updater> diagnostic_updater_;
 
@@ -291,6 +347,7 @@ private:
   std::size_t clouds_published_{0};
   std::size_t tf_failures_{0};
   std::size_t nonfinite_dropped_{0};
+  std::size_t low_confidence_dropped_{0};
   rclcpp::Time last_frame_time_;
   rclcpp::Time last_publish_time_;
   rclcpp::Time last_tf_failure_time_;

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -200,6 +200,44 @@ TEST(ProjectObstaclePixels, NadirCenterPixelHitsOrigin)
   EXPECT_EQ(points[0].intensity, 200);
 }
 
+// The obstacle_prob_min floor drops low-confidence obstacle pixels
+// (P(obstacle) = R/(R+G+B) below the floor) before projection, keeping
+// high-confidence ones. Two R-dominant pixels under a nadir camera (both
+// project): high confidence (200,20,20) -> P≈0.83, low confidence
+// (100,90,60) -> P≈0.40 (still R-dominant, so is_obstacle_pixel passes).
+TEST(ProjectObstaclePixels, ObstacleProbMinDropsLowConfidence)
+{
+  const auto model = make_camera_model();
+  const cv::Vec3d camera_origin(0.0, 0.0, 1.0);
+  const auto rotation = nadir_rotation();
+
+  cv::Mat mask(480, 640, CV_8UC3, cv::Scalar(0, 0, 0));
+  mask.at<cv::Vec3b>(240, 320) = cv::Vec3b(200, 20, 20);   // P ≈ 0.83
+  mask.at<cv::Vec3b>(240, 100) = cv::Vec3b(100, 90, 60);   // P ≈ 0.40
+
+  // Floor disabled (default 0.0): both obstacle pixels project.
+  {
+    ProjectionStats stats;
+    const auto points =
+      project_obstacle_pixels(mask, model, camera_origin, rotation, 0.0, &stats);
+    EXPECT_EQ(stats.obstacle_pixels, 2u);
+    EXPECT_EQ(points.size(), 2u);
+    EXPECT_EQ(stats.dropped_low_confidence, 0u);
+  }
+
+  // Floor 0.60: only the high-confidence pixel survives; the 0.40 pixel is
+  // counted as a low-confidence drop.
+  {
+    ProjectionStats stats;
+    const auto points =
+      project_obstacle_pixels(mask, model, camera_origin, rotation, 0.0, &stats, 0.60);
+    EXPECT_EQ(stats.obstacle_pixels, 2u);
+    ASSERT_EQ(points.size(), 1u);
+    EXPECT_EQ(stats.dropped_low_confidence, 1u);
+    EXPECT_EQ(points[0].intensity, 200);  // the surviving high-confidence pixel
+  }
+}
+
 // A pixel to the right of the principal point under a nadir camera
 // projects to a point in the camera's right direction. With our
 // nadir_rotation, optical_+x maps to target_+x, so the projected

--- a/sea_surface_segmentation/test/test_segments_projection.cpp
+++ b/sea_surface_segmentation/test/test_segments_projection.cpp
@@ -238,6 +238,25 @@ TEST(ProjectObstaclePixels, ObstacleProbMinDropsLowConfidence)
   }
 }
 
+// Boundary: a pixel at exactly P(obstacle) == floor must be KEPT — the gate is
+// `>=`, not `>`. R=120, G=B=60 -> 120/240 = 0.50 exactly; floor 0.50 keeps it.
+TEST(ProjectObstaclePixels, ObstacleProbMinBoundaryKeepsEqual)
+{
+  const auto model = make_camera_model();
+  const cv::Vec3d camera_origin(0.0, 0.0, 1.0);
+  const auto rotation = nadir_rotation();
+
+  cv::Mat mask(480, 640, CV_8UC3, cv::Scalar(0, 0, 0));
+  mask.at<cv::Vec3b>(240, 320) = cv::Vec3b(120, 60, 60);  // P = 120/240 = 0.50
+
+  ProjectionStats stats;
+  const auto points =
+    project_obstacle_pixels(mask, model, camera_origin, rotation, 0.0, &stats, 0.50);
+  EXPECT_EQ(stats.obstacle_pixels, 1u);
+  ASSERT_EQ(points.size(), 1u);  // P == floor is kept (>=)
+  EXPECT_EQ(stats.dropped_low_confidence, 0u);
+}
+
 // A pixel to the right of the principal point under a nadir camera
 // projects to a point in the camera's right direction. With our
 // nadir_rotation, optical_+x maps to target_+x, so the projected


### PR DESCRIPTION
## What

Adds an **obstacle-probability confidence floor** to the reflex obstacle feed.
`segments_to_pointcloud` / `project_obstacle_pixels` now projects an obstacle pixel only if
`P(obstacle) = R/(R+G+B) >= obstacle_prob_min`.

## Why

The reflex feed had **no confidence gate** (bare `R>G && R>B` argmax) while the costmap layer
filters at `obstacle_prob_min`. That asymmetry is why calm-water reflections (~0.55 confidence)
trip the collision-monitor e-stop. This brings the reflex to parity.

## How

- `project_obstacle_pixels` (header): new `obstacle_prob_min` arg, **placed last with default
  `0.0`** so all callers — including out-of-package tools (`sea_surface_tuner`) — compile
  unchanged. New `dropped_low_confidence` stat.
- `segments_to_pointcloud` node: declares the param with a **`ParameterDescriptor`** (range
  0–1, step 0.05, description) + a live `on_set_parameters` callback, so it retunes via
  `ros2 param set` / `rqt_reconfigure` without relaunch and is forward-compatible with the
  `marine_control` parameter-descriptor binding (unh_marine_autonomy#140 / ADR-0003). Surfaced
  on `/diagnostics`.
- Generic default stays `0.0` (off — **no behavior change for any consumer**); BizzyBoat's
  validated `0.60` ("Balanced") lands in the overlay separately.

## Tests / verification

- New unit test `ObstacleProbMinDropsLowConfidence`: floor off → both pixels project; floor 0.60
  → only the 0.83-confidence pixel survives, the 0.40 one is counted as a low-confidence drop.
- `colcon build` + `colcon test` pass (gtest: `ProjectObstaclePixels` 11/11, all suites 0
  failures); no lint failures on the changed files.

## Scope / follow-ups

Capability only; behavior change for BizzyBoat lands via the overlay default + `min_points`
(separate PRs). The eWaSR retrain (#34) is the durable fix for high-confidence bright
reflections that no reflex threshold can separate.

Note: full `/review-code` Copilot adversarial pass not run (GitHub Copilot monthly quota
exhausted this cycle); change is small, built, tested, and self-reviewed.

Closes #35 · Related #31, #30, #34

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
