### PR TITLE
launch: expose obstacle_prob_min in segments_to_pointcloud_launch.py

### DIFF
--- a/sea_surface_segmentation/launch/segments_to_pointcloud_launch.py
+++ b/sea_surface_segmentation/launch/segments_to_pointcloud_launch.py
@@ -4,6 +4,7 @@ from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression
 from launch_ros.actions import LifecycleNode
 from launch_ros.actions import LifecycleTransition
+from launch_ros.parameter_descriptions import ParameterValue
 
 from lifecycle_msgs.msg import Transition
 
@@ -24,6 +25,12 @@ def generate_launch_description():
     # independent feed for the Collision Monitor reflex layer.
     target_frame = LaunchConfiguration('target_frame', default='')
 
+    # Reflex confidence floor (see segments_projection.hpp / #35). Default 0.0 =
+    # off, so existing includers are unaffected; platforms pass a positive value
+    # (BizzyBoat: 0.60) to reject low-confidence returns like calm-water
+    # reflections.
+    obstacle_prob_min = LaunchConfiguration('obstacle_prob_min', default='0.0')
+
     return LaunchDescription([
         DeclareLaunchArgument(
             'name',
@@ -43,6 +50,15 @@ def generate_launch_description():
                 'nav2_collision_monitor reflex feed.'
             ),
         ),
+        DeclareLaunchArgument(
+            'obstacle_prob_min',
+            default_value='0.0',
+            description=(
+                'Reflex confidence floor: project an obstacle pixel only if '
+                'P(obstacle)=R/(R+G+B) >= this. 0.0 (default) disables the gate; '
+                'platforms raise it to reject low-confidence reflections.'
+            ),
+        ),
         LifecycleNode(
             package='sea_surface_segmentation',
             executable='segments_to_pointcloud',
@@ -50,6 +66,9 @@ def generate_launch_description():
             namespace='',
             parameters=[{
                 'target_frame': target_frame,
+                # Cast the string launch arg to double for the node's param.
+                'obstacle_prob_min': ParameterValue(
+                    obstacle_prob_min, value_type=float),
             }],
             respawn=True,
             respawn_delay=2,

--- a/sea_surface_segmentation/launch/segments_to_pointcloud_launch.py
+++ b/sea_surface_segmentation/launch/segments_to_pointcloud_launch.py
@@ -55,8 +55,9 @@ def generate_launch_description():
             default_value='0.0',
             description=(
                 'Reflex confidence floor: project an obstacle pixel only if '
-                'P(obstacle)=R/(R+G+B) >= this. 0.0 (default) disables the gate; '
-                'platforms raise it to reject low-confidence reflections.'
+                'P(obstacle)=R/(R+G+B) >= this. 0.0 (default) disables the gate. '
+                'Valid range 0.0-0.95 (the node rejects higher values). Platforms '
+                'raise it to reject low-confidence reflections.'
             ),
         ),
         LifecycleNode(


### PR DESCRIPTION
## What
Expose `obstacle_prob_min` (the reflex confidence floor from #35) as a launch argument in the
generic `segments_to_pointcloud_launch.py`, cast to `double` for the node parameter.

## Why
The launch file only forwarded `name`/`target_frame`, so platform launches couldn't set the
floor. Default `0.0` = off → no behavior change for existing includers. BizzyBoat sets `0.60` in
its overlay (`unh_echoboats_project11`, separate PR) to activate it for the June survey.

## Verification
`generate_launch_description()` loads cleanly (5 entities); the new `ParameterValue(..., value_type=float)`
casts the string launch arg to the node's `double` param.

Closes #37 · Follow-up to #35

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
