### PR TITLE
Wire reflex node (segments_to_pointcloud) into marine_control device control

### DIFF
--- a/.agent/work-plans/issue-39/progress.md
+++ b/.agent/work-plans/issue-39/progress.md
@@ -1,0 +1,30 @@
+---
+issue: 39
+---
+
+# Issue #39 — Wire reflex node (segments_to_pointcloud) into marine_control device control
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-27 16:46 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-39 at `d356da8`
+**Mode**: pre-push
+**Depth**: Standard (reason: safety-critical lifecycle node + ~256 lines across 4 files)
+**Must-fix**: 0 | **Suggestions**: 5 (all addressed)
+**Round**: 1 | **Ship**: recommended — no must-fix; both adversarial lenses converged, all suggestions applied.
+
+Two disjoint-lens Claude adversarial passes (Lens A logic, Lens B systemic/safety)
+cross-confirmed each other. No must-fix findings. The 0.95 cap is double-guarded
+(FloatingPointRange descriptor + on-set callback) with no write path around the
+validated `set_parameters` route — confirmed sound by both passes.
+
+### Findings
+- [x] (suggestion) on-set callback wrote cached floor during validation — split into validate (on-set) + commit (post-set) so a rejected batched set can't desync cache — `segments_to_pointcloud.cpp:107`
+- [x] (suggestion) SingleThreadedExecutor is load-bearing for the ControlServer threading contract — documented in `main()` — `segments_to_pointcloud.cpp:393`
+- [x] (suggestion) rejection test could pass vacuously (dropped vs rejected) — added in-range sentinel after the out-of-range request + max-observed tracking — `test_segments_to_pointcloud_control.py:test_out_of_range_change_is_rejected`
+- [x] (suggestion) test imports marine_control_interfaces directly but only had transitive dep — added `<test_depend>` — `package.xml:38`
+- [x] (suggestion) docstring numbering implied execution order — noted tests are self-contained / alphabetical — `test_segments_to_pointcloud_control.py`
+- [ ] (deferred) `on_error` override does not reset the control server on the active→ErrorProcessing path — latent only (no callback triggers the error transition for this node); not addressed.

--- a/sea_surface_segmentation/CMakeLists.txt
+++ b/sea_surface_segmentation/CMakeLists.txt
@@ -32,6 +32,7 @@ include_directories(${grid_map_core_INC})
 # expose the same dir to downstream packages (unh_marine_perception#23).
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 find_package(lifecycle_msgs REQUIRED)
+find_package(marine_control REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
 find_package(pcl_conversions REQUIRED)
@@ -79,6 +80,7 @@ target_link_libraries(segments_to_pointcloud
 
 ament_target_dependencies(segments_to_pointcloud
   cv_bridge
+  marine_control
   pcl_ros
 )
 
@@ -254,6 +256,14 @@ if(BUILD_TESTING)
   # assert obstacle points land in the forward danger sector. This
   # is the deployment-evidence regression for #17.
   add_launch_test(test/test_segments_to_pointcloud_bag.py
+    TIMEOUT 60
+  )
+
+  # marine_control device-control wiring (unh_marine_autonomy#140 / ADR-0003):
+  # brings the node to active, asserts the obstacle_prob_min floor is advertised
+  # on ~/control/state, that an in-range change applies, and that an out-of-range
+  # change is rejected (the operator cannot blind the reflex feed remotely).
+  add_launch_test(test/test_segments_to_pointcloud_control.py
     TIMEOUT 60
   )
 endif()

--- a/sea_surface_segmentation/package.xml
+++ b/sea_surface_segmentation/package.xml
@@ -36,6 +36,7 @@
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>marine_control_interfaces</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>

--- a/sea_surface_segmentation/package.xml
+++ b/sea_surface_segmentation/package.xml
@@ -20,6 +20,7 @@
   <depend>image_geometry</depend>
   <depend>libopencv-dev</depend>
   <depend>lifecycle_msgs</depend>
+  <depend>marine_control</depend>
   <depend>nav2_costmap_2d</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>

--- a/sea_surface_segmentation/src/segments_to_pointcloud.cpp
+++ b/sea_surface_segmentation/src/segments_to_pointcloud.cpp
@@ -103,14 +103,18 @@ public:
     }
     obstacle_prob_min_ = get_parameter("obstacle_prob_min").as_double();
 
-    // Keep obstacle_prob_min_ live so rqt_reconfigure / `ros2 param set` / the
-    // marine_control panel (bound in on_activate) retune it without a relaunch.
-    // This callback is the single owner of the 0.95 cap, so it validates
-    // operator changes arriving over marine_control too. Guarded so a
-    // configure -> cleanup -> configure cycle registers exactly one callback.
+    // Validate changes to the floor from rqt_reconfigure / `ros2 param set` /
+    // the marine_control panel (bound in on_activate). This on-set callback is
+    // the single owner of the 0.95 cap and the NaN guard (the FloatingPointRange
+    // descriptor enforces the range but not NaN). It validates *only*: the
+    // cached obstacle_prob_min_ is committed in the post-set callback below, so a
+    // value rejected here — or by another parameter sharing the same set() —
+    // can never move the cache ahead of the declared parameter. Both callbacks
+    // are guarded so a configure -> cleanup -> configure cycle registers exactly
+    // one of each.
     if (!param_cb_handle_) {
       param_cb_handle_ = add_on_set_parameters_callback(
-        [this](const std::vector<rclcpp::Parameter> & params) {
+        [](const std::vector<rclcpp::Parameter> & params) {
           rcl_interfaces::msg::SetParametersResult result;
           result.successful = true;
           for (const auto & p : params) {
@@ -119,12 +123,23 @@ public:
               if (!std::isfinite(v) || v < 0.0 || v > 0.95) {
                 result.successful = false;
                 result.reason = "obstacle_prob_min must be finite and in [0, 0.95]";
-              } else {
-                obstacle_prob_min_ = v;
               }
             }
           }
           return result;
+        });
+    }
+    // Commit the validated value to the cache only after the set is applied, so
+    // obstacle_prob_min_ (read once per frame by segmentsCallback) always tracks
+    // the declared parameter — even when the change rides in a batched set().
+    if (!post_set_cb_handle_) {
+      post_set_cb_handle_ = add_post_set_parameters_callback(
+        [this](const std::vector<rclcpp::Parameter> & params) {
+          for (const auto & p : params) {
+            if (p.get_name() == "obstacle_prob_min") {
+              obstacle_prob_min_ = p.as_double();
+            }
+          }
         });
     }
 
@@ -383,6 +398,7 @@ private:
   double projection_plane_z_{0.0};
   double obstacle_prob_min_{0.0};
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_handle_;
+  rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr post_set_cb_handle_;
 
   // Boat-side device-control server: publishes obstacle_prob_min as a bridgeable
   // marine_control, applies operator changes via the bound parameter (whose
@@ -411,6 +427,13 @@ int main(int argc, char **argv)
   rclcpp::init(argc, argv);
   auto segments_to_pointcloud = std::make_shared<SegmentsToPointCloud>();
 
+  // The SingleThreadedExecutor is load-bearing for the marine_control
+  // ControlServer threading contract (control_server.hpp): bind_parameter() runs
+  // in on_activate and reset() in on_deactivate, both on this executor thread
+  // while spinning. A single thread cannot dispatch the server's heartbeat/change
+  // callbacks concurrently with those transitions, so the unlocked binding table
+  // is safe. Switching to a MultiThreadedExecutor (or composing this node into a
+  // multi-threaded container) would void that guarantee — don't, without revisiting.
   rclcpp::executors::SingleThreadedExecutor exe;
   exe.add_node(segments_to_pointcloud->get_node_base_interface());
   exe.spin();

--- a/sea_surface_segmentation/src/segments_to_pointcloud.cpp
+++ b/sea_surface_segmentation/src/segments_to_pointcloud.cpp
@@ -16,6 +16,8 @@
 #include "rcl_interfaces/msg/floating_point_range.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
 
+#include "marine_control/control_server.hpp"
+
 #include "cv_bridge/cv_bridge.hpp"
 
 #include <pcl/point_cloud.h>
@@ -101,9 +103,11 @@ public:
     }
     obstacle_prob_min_ = get_parameter("obstacle_prob_min").as_double();
 
-    // Keep obstacle_prob_min_ live so rqt_reconfigure / `ros2 param set` (and,
-    // later, the marine_control panel) retune it without a relaunch. Guarded so
-    // a configure -> cleanup -> configure cycle registers exactly one callback.
+    // Keep obstacle_prob_min_ live so rqt_reconfigure / `ros2 param set` / the
+    // marine_control panel (bound in on_activate) retune it without a relaunch.
+    // This callback is the single owner of the 0.95 cap, so it validates
+    // operator changes arriving over marine_control too. Guarded so a
+    // configure -> cleanup -> configure cycle registers exactly one callback.
     if (!param_cb_handle_) {
       param_cb_handle_ = add_on_set_parameters_callback(
         [this](const std::vector<rclcpp::Parameter> & params) {
@@ -171,17 +175,42 @@ public:
 
   CallbackReturn on_activate(const rclcpp_lifecycle::State &state)
   {
+    // Expose the reflex confidence floor on the marine_control device panel so
+    // the operator can retune it live, bridgeable boat->operator
+    // (unh_marine_autonomy#140 / ADR-0003). Built here — not in on_configure —
+    // so the control channel exists only while the reflex feed is active
+    // (lifecycle gating per control_server.hpp), and torn down in on_deactivate.
+    //
+    // Safety (ADR-0003 D8.3): this rides the base fire-and-forget change
+    // channel. That is acceptable only because obstacle_prob_min's own on-set
+    // callback caps the value at 0.95, so an operator setting cannot blind the
+    // reflex feed. Stronger confirm/audit is the documented marine_control
+    // follow-up, not done here.
+    marine_control::ControlServerOptions control_opts;
+    control_opts.device_name = "Reflex Obstacle Filter";
+    control_server_ = std::make_shared<marine_control::ControlServer>(this, control_opts);
+    control_server_->bind_parameter("obstacle_prob_min", "P", "reflex");
     return LifecycleNode::on_activate(state);
   }
 
 
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State &state)
   {
+    // Tear down the control channel so the panel stops advertising a control
+    // for an inactive reflex, and the heartbeat timer/change sub are gone.
+    // Safe to destroy here: the node runs on a SingleThreadedExecutor, so this
+    // callback never races an in-flight ControlServer callback (control_server.hpp
+    // threading contract).
+    control_server_.reset();
     return LifecycleNode::on_deactivate(state);
   }
 
   CallbackReturn on_cleanup(const rclcpp_lifecycle::State &state)
   {
+    // Idempotent: deactivate already reset the server on the active->inactive
+    // path; reset again so a configure->cleanup (never-activated) path also
+    // leaves no dangling server.
+    control_server_.reset();
     return LifecycleNode::on_cleanup(state);
   }
 
@@ -354,6 +383,12 @@ private:
   double projection_plane_z_{0.0};
   double obstacle_prob_min_{0.0};
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_handle_;
+
+  // Boat-side device-control server: publishes obstacle_prob_min as a bridgeable
+  // marine_control, applies operator changes via the bound parameter (whose
+  // on-set validation still owns the 0.95 cap). Lives only while active; see
+  // on_activate/on_deactivate.
+  std::shared_ptr<marine_control::ControlServer> control_server_;
 
   std::unique_ptr<diagnostic_updater::Updater> diagnostic_updater_;
 

--- a/sea_surface_segmentation/test/test_segments_to_pointcloud_control.py
+++ b/sea_surface_segmentation/test/test_segments_to_pointcloud_control.py
@@ -19,6 +19,10 @@ adopter — not the library in isolation:
 No camera/bag data is needed: the control channel is independent of the
 projection pipeline, so the node sits idle on its image subscriptions while the
 control server runs.
+
+The numbered scenarios above describe coverage, not execution order: unittest
+runs the methods alphabetically, and each is self-contained (it re-establishes
+any baseline it needs), so order does not matter.
 """
 
 import time
@@ -51,6 +55,11 @@ EXPECTED_MAX = 0.95
 # An in-range request the cap accepts, and an out-of-range one it must reject.
 IN_RANGE_VALUE = 0.6
 OUT_OF_RANGE_VALUE = 0.99
+# A second in-range value, distinct from IN_RANGE_VALUE, sent *after* the
+# out-of-range request. marine_control uses RELIABLE ordered delivery, so if this
+# sentinel is applied the out-of-range request was delivered and processed before
+# it — which distinguishes "rejected by the cap" from "silently dropped".
+SENTINEL_VALUE = 0.7
 
 # Heartbeat is 1 Hz; allow generous slack for lifecycle transitions + discovery.
 TEST_TIMEOUT_SECONDS = 25.0
@@ -133,6 +142,23 @@ class TestReflexControlChannel(unittest.TestCase):
         msg.value = repr(float(value))
         self.change_pub.publish(msg)
 
+    def _current_value(self):
+        item = self._find_item(self.latest) if self.latest else None
+        return None if item is None else float(item.value)
+
+    def _drive_to(self, value):
+        """Predicate that (re)sends `value` and reports whether the echo shows it.
+
+        Sending on each poll tolerates the change racing the subscription's
+        discovery/connection; RELIABLE delivery makes the repeats harmless.
+        """
+        def predicate():
+            self._send_change(value)
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            current = self._current_value()
+            return current is not None and abs(current - value) < 1e-6
+        return predicate
+
     def test_state_advertises_obstacle_prob_min(self):
         got = self._spin_until(lambda: self.latest is not None)
         self.assertTrue(
@@ -156,47 +182,48 @@ class TestReflexControlChannel(unittest.TestCase):
         self.assertEqual(item.group, 'reflex')
 
     def test_in_range_change_is_applied(self):
-        self.assertTrue(self._spin_until(lambda: self.latest is not None))
-
-        def applied():
-            self._send_change(IN_RANGE_VALUE)
-            rclpy.spin_once(self.node, timeout_sec=0.1)
-            item = self._find_item(self.latest) if self.latest else None
-            return item is not None and abs(float(item.value) - IN_RANGE_VALUE) < 1e-6
-
         self.assertTrue(
-            self._spin_until(applied),
+            self._spin_until(self._drive_to(IN_RANGE_VALUE)),
             f'in-range change to {IN_RANGE_VALUE} was not reflected in the '
             f'state echo; the change channel did not apply the bound parameter.')
 
     def test_out_of_range_change_is_rejected(self):
-        # First drive the value to a known in-range setting.
-        def applied():
-            self._send_change(IN_RANGE_VALUE)
-            rclpy.spin_once(self.node, timeout_sec=0.1)
-            item = self._find_item(self.latest) if self.latest else None
-            return item is not None and abs(float(item.value) - IN_RANGE_VALUE) < 1e-6
+        # Drive to a known in-range value first; this also proves the change
+        # channel is live in this test method (independent of test order).
+        self.assertTrue(
+            self._spin_until(self._drive_to(IN_RANGE_VALUE)),
+            'could not establish the in-range baseline before the rejection test.')
 
-        self.assertTrue(self._spin_until(applied))
-
-        # Now request an out-of-range value. The parameter's bounds (0.95 cap)
-        # must reject it: the echoed value stays at the last accepted setting.
-        # If this regresses, an operator could blind the reflex feed remotely.
+        # Request the out-of-range value, immediately followed by an in-range
+        # sentinel. Track the max value ever echoed across the wait: the cap must
+        # never be exceeded. Waiting for the sentinel to land confirms (via
+        # RELIABLE ordered delivery) that the out-of-range request was delivered
+        # and processed — not merely dropped — so the test cannot pass vacuously.
+        max_seen = IN_RANGE_VALUE
         self._send_change(OUT_OF_RANGE_VALUE)
-        deadline = time.monotonic() + 3.0
-        while time.monotonic() < deadline:
-            rclpy.spin_once(self.node, timeout_sec=0.1)
+        self._send_change(SENTINEL_VALUE)
 
-        item = self._find_item(self.latest)
-        self.assertIsNotNone(item)
+        def sentinel_applied():
+            nonlocal max_seen
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            current = self._current_value()
+            if current is None:
+                return False
+            max_seen = max(max_seen, current)
+            return abs(current - SENTINEL_VALUE) < 1e-6
+
+        self.assertTrue(
+            self._spin_until(sentinel_applied),
+            f'sentinel change to {SENTINEL_VALUE} (sent right after the '
+            f'out-of-range request) never landed; cannot confirm the '
+            f'out-of-range request was delivered rather than dropped.')
         self.assertLessEqual(
-            float(item.value), EXPECTED_MAX,
-            f'out-of-range change to {OUT_OF_RANGE_VALUE} was accepted; the '
-            f'reflex confidence floor must stay capped at {EXPECTED_MAX} over '
-            f'the marine_control channel (ADR-0003 D8.3 safety contract).')
-        self.assertAlmostEqual(
-            float(item.value), IN_RANGE_VALUE, places=6,
-            msg='rejected change must leave the prior accepted value intact.')
+            max_seen, EXPECTED_MAX,
+            f'an echoed value exceeded the {EXPECTED_MAX} cap; the out-of-range '
+            f'change to {OUT_OF_RANGE_VALUE} was accepted. The reflex confidence '
+            f'floor must stay capped over the marine_control channel '
+            f'(ADR-0003 D8.3 safety contract) — an operator must not be able to '
+            f'blind the reflex feed remotely.')
 
 
 @launch_testing.post_shutdown_test()

--- a/sea_surface_segmentation/test/test_segments_to_pointcloud_control.py
+++ b/sea_surface_segmentation/test/test_segments_to_pointcloud_control.py
@@ -1,0 +1,207 @@
+"""launch_testing integration: bring `segments_to_pointcloud` to the active
+lifecycle state and exercise its marine_control device-control channel
+(unh_marine_autonomy#140 / ADR-0003).
+
+Asserts the actual wiring added when the reflex node became a marine_control
+adopter — not the library in isolation:
+
+  1. While active, the node publishes a ControlSet on `~/control/state`
+     advertising exactly the reflex confidence floor (`obstacle_prob_min`),
+     with the descriptor's bounds (0.0–0.95) carried through to the UI item.
+  2. A ControlValue change on `~/control/change` for an in-range value is
+     applied to the bound parameter and confirmed by the next state echo.
+  3. **Safety contract (the load-bearing assertion):** an out-of-range change
+     (> 0.95) is rejected, so the echoed value does not move. The parameter's
+     own bounds/validation remain the guard against an operator blinding the
+     reflex feed over the remote channel — fire-and-forget cannot bypass it
+     (ADR-0003 D8.3).
+
+No camera/bag data is needed: the control channel is independent of the
+projection pipeline, so the node sits idle on its image subscriptions while the
+control server runs.
+"""
+
+import time
+import unittest
+
+import pytest
+import rclpy
+from lifecycle_msgs.msg import Transition
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from std_msgs.msg import Header
+
+from marine_control_interfaces.msg import ControlItem, ControlSet, ControlValue
+
+import launch_testing
+import launch_testing.actions
+from launch import LaunchDescription
+from launch_ros.actions import LifecycleNode
+from launch_ros.actions import LifecycleTransition
+
+NAMESPACE = '/test_reflex'
+NODE_NAME = 'segments_to_pointcloud'
+STATE_TOPIC = f'{NAMESPACE}/{NODE_NAME}/control/state'
+CHANGE_TOPIC = f'{NAMESPACE}/{NODE_NAME}/control/change'
+
+CONTROL_NAME = 'obstacle_prob_min'
+EXPECTED_DEVICE_NAME = 'Reflex Obstacle Filter'
+EXPECTED_MIN = 0.0
+EXPECTED_MAX = 0.95
+
+# An in-range request the cap accepts, and an out-of-range one it must reject.
+IN_RANGE_VALUE = 0.6
+OUT_OF_RANGE_VALUE = 0.99
+
+# Heartbeat is 1 Hz; allow generous slack for lifecycle transitions + discovery.
+TEST_TIMEOUT_SECONDS = 25.0
+
+# marine_control state QoS: RELIABLE + VOLATILE (ADR-0003 D5). A best-effort or
+# transient-local subscriber would mismatch and silently receive nothing.
+_CONTROL_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    durability=DurabilityPolicy.VOLATILE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=10,
+)
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    node = LifecycleNode(
+        package='sea_surface_segmentation',
+        executable=NODE_NAME,
+        name=NODE_NAME,
+        namespace=NAMESPACE,
+        output='screen',
+    )
+
+    transition = LifecycleTransition(
+        lifecycle_node_names=[f'{NAMESPACE}/{NODE_NAME}'],
+        transition_ids=(
+            Transition.TRANSITION_CONFIGURE,
+            Transition.TRANSITION_ACTIVATE,
+        ),
+    )
+
+    return LaunchDescription([
+        node,
+        transition,
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+
+class TestReflexControlChannel(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('reflex_control_test')
+        cls.latest = None
+
+        def on_state(msg: ControlSet):
+            cls.latest = msg
+
+        cls.sub = cls.node.create_subscription(
+            ControlSet, STATE_TOPIC, on_state, _CONTROL_QOS)
+        cls.change_pub = cls.node.create_publisher(
+            ControlValue, CHANGE_TOPIC, _CONTROL_QOS)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def _spin_until(self, predicate, timeout=TEST_TIMEOUT_SECONDS):
+        start = time.monotonic()
+        while time.monotonic() - start < timeout:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if predicate():
+                return True
+        return False
+
+    def _find_item(self, control_set):
+        for item in control_set.items:
+            if item.name == CONTROL_NAME:
+                return item
+        return None
+
+    def _send_change(self, value):
+        msg = ControlValue()
+        msg.header = Header()
+        msg.name = CONTROL_NAME
+        # Stringified per the item type (FLOAT); the server parses it back.
+        msg.value = repr(float(value))
+        self.change_pub.publish(msg)
+
+    def test_state_advertises_obstacle_prob_min(self):
+        got = self._spin_until(lambda: self.latest is not None)
+        self.assertTrue(
+            got,
+            f'no ControlSet received on {STATE_TOPIC} within '
+            f'{TEST_TIMEOUT_SECONDS}s; the node may not have reached the active '
+            f'state, or the marine_control server was not constructed in '
+            f'on_activate.')
+
+        self.assertEqual(self.latest.device_name, EXPECTED_DEVICE_NAME)
+
+        item = self._find_item(self.latest)
+        self.assertIsNotNone(
+            item,
+            f'ControlSet did not advertise {CONTROL_NAME!r}; items='
+            f'{[i.name for i in self.latest.items]}')
+        self.assertEqual(item.type, ControlItem.TYPE_FLOAT)
+        self.assertAlmostEqual(item.min_value, EXPECTED_MIN, places=6)
+        self.assertAlmostEqual(item.max_value, EXPECTED_MAX, places=6)
+        self.assertEqual(item.units, 'P')
+        self.assertEqual(item.group, 'reflex')
+
+    def test_in_range_change_is_applied(self):
+        self.assertTrue(self._spin_until(lambda: self.latest is not None))
+
+        def applied():
+            self._send_change(IN_RANGE_VALUE)
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            item = self._find_item(self.latest) if self.latest else None
+            return item is not None and abs(float(item.value) - IN_RANGE_VALUE) < 1e-6
+
+        self.assertTrue(
+            self._spin_until(applied),
+            f'in-range change to {IN_RANGE_VALUE} was not reflected in the '
+            f'state echo; the change channel did not apply the bound parameter.')
+
+    def test_out_of_range_change_is_rejected(self):
+        # First drive the value to a known in-range setting.
+        def applied():
+            self._send_change(IN_RANGE_VALUE)
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            item = self._find_item(self.latest) if self.latest else None
+            return item is not None and abs(float(item.value) - IN_RANGE_VALUE) < 1e-6
+
+        self.assertTrue(self._spin_until(applied))
+
+        # Now request an out-of-range value. The parameter's bounds (0.95 cap)
+        # must reject it: the echoed value stays at the last accepted setting.
+        # If this regresses, an operator could blind the reflex feed remotely.
+        self._send_change(OUT_OF_RANGE_VALUE)
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        item = self._find_item(self.latest)
+        self.assertIsNotNone(item)
+        self.assertLessEqual(
+            float(item.value), EXPECTED_MAX,
+            f'out-of-range change to {OUT_OF_RANGE_VALUE} was accepted; the '
+            f'reflex confidence floor must stay capped at {EXPECTED_MAX} over '
+            f'the marine_control channel (ADR-0003 D8.3 safety contract).')
+        self.assertAlmostEqual(
+            float(item.value), IN_RANGE_VALUE, places=6,
+            msg='rejected change must leave the prior accepted value intact.')
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessShutdown(unittest.TestCase):
+
+    def test_clean_exit(self, proc_info):
+        # The node is killed by launch teardown; no stricter assertion needed.
+        pass


### PR DESCRIPTION
## Summary

Wires the reflex collision-monitor node (`segments_to_pointcloud`, a
`LifecycleNode` in `sea_surface_segmentation`) into the **marine_control**
device-control system so the operator can retune its reflex confidence floor
(`obstacle_prob_min`) live from the `rqt_marine_control` panel, bridgeable
boat→operator. This is the "segments_to_pointcloud floor" adopter for the
marine_control rollout.

## What changed

- **`package.xml` / `CMakeLists.txt`** — depend on `marine_control`; link it
  into the `segments_to_pointcloud` target. Added `marine_control_interfaces`
  as a `test_depend` (the launch test imports it directly).
- **`segments_to_pointcloud.cpp`**
  - Construct a `marine_control::ControlServer` in `on_activate()`, `reset()` in
    `on_deactivate()`/`on_cleanup()` — the lifecycle-gating pattern from
    `control_server.hpp`, so the panel advertises a control only while the reflex
    feed is active.
  - `bind_parameter("obstacle_prob_min", "P", "reflex")`.
  - Split the parameter callback: on-set **validates** (owns the 0.95 cap + NaN
    guard), a new post-set callback **commits** the cached value — so a value
    rejected in a batched `set()` can never move the cached floor ahead of the
    declared parameter.
  - Documented that the `SingleThreadedExecutor` in `main()` is load-bearing for
    the ControlServer threading contract.
- **`test/test_segments_to_pointcloud_control.py`** (new launch test) — brings
  the node to active and asserts: the floor is advertised on `~/control/state`
  with its bounds; an in-range change applies; an **out-of-range change is
  rejected** (sentinel-after-reject + max-observed tracking distinguishes
  "rejected" from "silently dropped"). Full package suite: **82 tests, 0
  failures**.

## Safety (ADR-0003 D8.3)

The change channel is fire-and-forget, but `obstacle_prob_min`'s own bounds are
double-guarded (FloatingPointRange descriptor **and** on-set callback) on the
validated `set_parameters` path — an operator cannot blind the reflex feed
remotely. The launch test exercises this directly.

## Review

Self-reviewed pre-push with two disjoint-lens adversarial passes (logic +
systemic/safety). They cross-confirmed each other; **no must-fix findings**. All
five suggestions were applied (see `progress.md`); one latent `on_error`-path
gap is documented and deferred (unreachable for this node — no callback triggers
the error transition).

## Out of scope

- Platform bridge routing of `~/control/state` / `~/control/change`
  (echoboats platform-repo config) — follow-up.
- Exposing other parameters (`projection_plane_z`, frame params) — floor only.

Part of rolker/unh_marine_autonomy#140 (marine_control device control, ADR-0003).
Related to #31 (whitecap false-triggers — the reason the floor exists).

Closes #39

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
